### PR TITLE
save user in request.resource_owner (solution by @ib-lundgren)

### DIFF
--- a/oauth2_provider/views/mixins.py
+++ b/oauth2_provider/views/mixins.py
@@ -165,6 +165,7 @@ class ProtectedResourceMixin(OAuthLibMixin):
     def dispatch(self, request, *args, **kwargs):
         valid, r = self.verify_request(request)
         if valid:
+            request.resource_owner = r.user
             return super(ProtectedResourceMixin, self).dispatch(request, *args, **kwargs)
         else:
             return HttpResponseForbidden()


### PR DESCRIPTION
Fix for issue: https://github.com/evonove/django-oauth-toolkit/issues/39

This allows to access the resource owner on a view while costing no extra lookups. See the discussion in the issue above. This implements the solution proposed by @ib-lundgren.
