### PR TITLE
raw_id_fields for all User foreign keys in the admins

### DIFF
--- a/oauth2_provider/admin.py
+++ b/oauth2_provider/admin.py
@@ -1,9 +1,13 @@
 from django.contrib import admin
+
 from .models import Grant, AccessToken, RefreshToken, get_application_model
+
+class RawIDAdmin(admin.ModelAdmin):
+    raw_id_fields = ('user',)
 
 Application = get_application_model()
 
-admin.site.register(Application)
-admin.site.register(Grant)
-admin.site.register(AccessToken)
-admin.site.register(RefreshToken)
+admin.site.register(Application, RawIDAdmin)
+admin.site.register(Grant, RawIDAdmin)
+admin.site.register(AccessToken, RawIDAdmin)
+admin.site.register(RefreshToken, RawIDAdmin)


### PR DESCRIPTION
With a large enough User table, the Admin will choke pulling in a dropdown containing all the User objects. It makes a lot more sense to make them raw_id_fields across all the admins.

I tinkered with making them a setting you could override, but this was nice and simple.
