### PR TITLE
AuthorizationView will return a successful redirect response

### DIFF
--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -117,7 +117,8 @@ class AuthorizationView(BaseAuthorizationView, FormView):
 
             # Check to see if the user has already granted access and return
             # a successful response
-            if request.user.accesstoken_set.filter(
+            require_approval = request.get('approval_prompt', 'auto') == 'auto'
+            if not require_approval and request.user.accesstoken_set.filter(
                         application=kwargs['application'],
                         expires__gt=datetime.datetime.now()).count():
                 uri, headers, body, status = self.create_authorization_response(


### PR DESCRIPTION
This replaces pull request #79 to allow for some updates.

Now it looks for the query parameter "approval_prompt". It defaults to "auto" in which case it will **not** show the approval prompt, if the user has previously approved the request.

If it is "force" (or anything else, really), the user will be prompted.
