### PR TITLE
Use ugettext_lazy to avoid django dev branch error

### DIFF
--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -4,7 +4,7 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils import timezone
 from django.db.models import get_model
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import python_2_unicode_compatible
 from django.core.exceptions import ImproperlyConfigured
 


### PR DESCRIPTION
Use ugettext_lazy to avoid the `RuntimeError: App registry isn't ready yet.` error with the current django master branch
