### PR TITLE
Don't pin django-braces and six versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,8 @@ setup(
     test_suite='runtests',
     install_requires=[
         'django>=1.4',
-        'django-braces==1.2.2',
-        'six==1.3.0',
+        'django-braces>=1.2.2',
+        'six>=1.3.0',
         'oauthlib==0.6.1',
     ],
     zip_safe=False,


### PR DESCRIPTION
These two pinned dependencies make the package uncompatible with other (or at least some of my corporate project)

I just accepted latest versions.
