### PR TITLE
Invalid block.super call in base template

### DIFF
--- a/oauth2_provider/templates/oauth2_provider/base.html
+++ b/oauth2_provider/templates/oauth2_provider/base.html
@@ -8,7 +8,6 @@
     <meta name="author" content="">
 
     {% block css %}
-        {{ block.super }}
         <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.no-icons.min.css" rel="stylesheet">
     {% endblock css %}
 


### PR DESCRIPTION
Since the base.html is not extending another template the call is invalid and should be removed.

(this fix also solves a problem when using compress see https://github.com/django-compressor/django-compressor/issues/542)
