### PR TITLE
Add more Django/Python to travis/tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,13 @@ env:
   - TOX_ENV=py27-django14
   - TOX_ENV=py27-django15
   - TOX_ENV=py27-django16
+  - TOX_ENV=py27-django17
   - TOX_ENV=py33-django15
   - TOX_ENV=py33-django16
+  - TOX_ENV=py33-django17
+  - TOX_ENV=py34-django15
+  - TOX_ENV=py34-django16
+  - TOX_ENV=py34-django17
   - TOX_ENV=docs
 
 install:

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Requirements
 ------------
 
 * Python 2.6, 2.7, 3.3, 3.4
-* Django 1.4, 1.5, 1.6, 1.7rc1
+* Django 1.4, 1.5, 1.6, 1.7
 
 Installation
 ------------

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ deps =
 [testenv:py27-django17]
 basepython = python2.7
 deps =
-    https://www.djangoproject.com/download/1.7c1/tarball/
+    Django<1.8
     {[testenv]deps}
 
 [testenv:py33-django15]
@@ -74,7 +74,7 @@ deps =
 [testenv:py33-django17]
 basepython = python3.3
 deps =
-    https://www.djangoproject.com/download/1.7c1/tarball/
+    Django<1.8
     {[testenv]deps}
 
 [testenv:py34-django15]
@@ -93,7 +93,7 @@ deps =
 [testenv:py34-django17]
 basepython = python3.4
 deps =
-    https://www.djangoproject.com/download/1.7c1/tarball/
+    Django<1.8
     {[testenv]deps}
 
 [testenv:docs]


### PR DESCRIPTION
- django 1.7 tests use 1.7.0 not the RC in tox. 
- Added python34 and django17 environments to travis config
