### PR TITLE
Return empty response on successful token revocation.

### DIFF
--- a/oauth2_provider/tests/test_token_revocation.py
+++ b/oauth2_provider/tests/test_token_revocation.py
@@ -57,6 +57,7 @@ class TestRevocationView(BaseTest):
         url = "{url}?{qs}".format(url=reverse('oauth2_provider:revoke-token'), qs=query_string)
         response = self.client.post(url)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b'')
         self.assertFalse(AccessToken.objects.filter(id=tok.id).exists())
 
     def test_revoke_access_token_with_hint(self):

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -168,7 +168,7 @@ class RevokeTokenView(CsrfExemptMixin, OAuthLibMixin, View):
 
     def post(self, request, *args, **kwargs):
         url, headers, body, status = self.create_revocation_response(request)
-        response = HttpResponse(content=body, status=status)
+        response = HttpResponse(content=body or '', status=status)
 
         for k, v in headers.items():
             response[k] = v


### PR DESCRIPTION
This is addressing issue #158.
