### PR TITLE
Prevent user passwords showing in error emails

### DIFF
--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -1,8 +1,10 @@
 import logging
 
 from django.http import HttpResponse, HttpResponseRedirect
+from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic import View, FormView
 from django.utils import timezone
+from django.utils.decorators import method_decorator
 
 from oauthlib.oauth2 import Server
 
@@ -150,6 +152,7 @@ class TokenView(CsrfExemptMixin, OAuthLibMixin, View):
     server_class = Server
     validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
 
+    @method_decorator(sensitive_post_parameters('password'))
     def post(self, request, *args, **kwargs):
         url, headers, body, status = self.create_token_response(request)
         response = HttpResponse(content=body, status=status)


### PR DESCRIPTION
Use the sensitive_post_parameters decorator to redact user passwords when an error occurs in the token view.

Currently if an error occurs when a user logs in via django-oauth-toolkit, admins will receive an email containing their password in plain text.
