### PR TITLE
Add client_id as a natural key to the default Application model

### DIFF
--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -151,9 +151,19 @@ class AbstractApplication(models.Model):
         return True
 
 
+class ApplicationManager(models.Manager):
+    def get_by_natural_key(self, client_id):
+        return self.get(client_id=client_id)
+
+
 class Application(AbstractApplication):
+    objects = ApplicationManager()
+
     class Meta(AbstractApplication.Meta):
         swappable = "OAUTH2_PROVIDER_APPLICATION_MODEL"
+
+    def natural_key(self):
+        return (self.client_id,)
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
Uses client_id as a natural key when serializing the default
Application model, so that when things like fixtures are loaded,
references are maintained even when the environment that the
fixture is being loaded to doesn't have the same primary keys as
the environment that the fixture dumped from.