### PR TITLE
Remove incorrect reference to requirements from docs

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -9,7 +9,6 @@ Fork `django-oauth-toolkit` repository on `GitHub <https://github.com/evonove/dj
 
  * Create a virtualenv and activate it
  * Clone your repository locally
- * cd into the repository and type `pip install -r requirements/optional.txt` (this will install both optional and base requirements, useful during development)
 
 Issues
 ======


### PR DESCRIPTION
The requirements files were deleted on 9th March 2017 when test requirements were moved to tox.ini. The issue of no requirements/optional.txt file was raised in issue 535, which can be closed if this PR is merged.