### PR TITLE
Feature/return error code when token is not valid

### DIFF
--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -111,9 +111,22 @@ class TestOAuth2Authentication(TestCase):
 
     @unittest.skipUnless(rest_framework_installed, "djangorestframework not installed")
     def test_authentication_denied(self):
+        response = self.client.get("/oauth2-test/")
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response["WWW-Authenticate"],
+            'Bearer realm="api"',
+        )
+
+    @unittest.skipUnless(rest_framework_installed, "djangorestframework not installed")
+    def test_authentication_denied_because_of_invalid_token(self):
         auth = self._create_authorization_header("fake-token")
         response = self.client.get("/oauth2-test/", HTTP_AUTHORIZATION=auth)
         self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response["WWW-Authenticate"],
+            'Bearer realm="api",error="invalid_token",error_description="The access token is invalid."',
+        )
 
     @unittest.skipUnless(rest_framework_installed, "djangorestframework not installed")
     def test_authentication_or_scope_denied(self):


### PR DESCRIPTION
This PR tries to implement the recommendations in https://tools.ietf.org/html/rfc6750#section-3. 
Namely, these changes will add the `error` and `error_description` attributes to the `WWW-Authenticate` header.


---

I think this relates to the comments in https://github.com/jazzband/django-oauth-toolkit/issues/453

CC: @veranika-sab  @emoragaf 