### PR TITLE
Return state with authorization denied error

### DIFF
--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -108,7 +108,7 @@ class OAuthLibCore(object):
         """
         try:
             if not allow:
-                raise oauth2.AccessDeniedError()
+                raise oauth2.AccessDeniedError(state=credentials.get("state", None))
 
             # add current user to credentials. this will be used by OAUTH2_VALIDATOR_CLASS
             credentials["user"] = request.user

--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -108,7 +108,8 @@ class OAuthLibCore(object):
         """
         try:
             if not allow:
-                raise oauth2.AccessDeniedError(state=credentials.get("state", None))
+                raise oauth2.AccessDeniedError(
+                    state=credentials.get("state", None))
 
             # add current user to credentials. this will be used by OAUTH2_VALIDATOR_CLASS
             credentials["user"] = request.user


### PR DESCRIPTION
Conforms to [rfc6749 section 4.1.2.1](https://tools.ietf.org/html/rfc6749#section-4.1.2.1)
> REQUIRED if a "state" parameter was present in the client
>         authorization request.  The exact value received from the
>         client.