### PR TITLE
Handle case broken in error handling - IPv6 URL

### DIFF
--- a/oauth2_provider/validators.py
+++ b/oauth2_provider/validators.py
@@ -27,7 +27,10 @@ class URIValidator(RegexValidator):
             # Trivial case failed. Try for possible IDN domain
             if value:
                 value = force_text(value)
-                scheme, netloc, path, query, fragment = urlsplit(value)
+                try:
+                    scheme, netloc, path, query, fragment = urlsplit(value)
+                except ValueError as e:
+                    raise ValidationError("Cannot parse Redirect URI. Error: {}".format(e))
                 try:
                     netloc = netloc.encode("idna").decode("ascii")  # IDN -> ACE
                 except UnicodeError:  # invalid domain part

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -28,6 +28,9 @@ class TestValidators(TestCase):
         self.assertRaises(ValidationError, validate_uris, bad_uri)
         bad_uri = "http:/example.com"
         self.assertRaises(ValidationError, validate_uris, bad_uri)
+        # Bad IPv6 URL, urlparse behaves differently for these
+        bad_uri = "https://[\"><script>alert()</script>"
+        self.assertRaises(ValidationError, validate_uris, bad_uri)
         bad_uri = "my-scheme://example.com"
         self.assertRaises(ValidationError, validate_uris, bad_uri)
         bad_uri = "sdklfsjlfjljdflksjlkfjsdkl"


### PR DESCRIPTION
Discovered in testing related to our project [AWX](https://github.com/ansible/awx), a django / rest framework application. In our implementation a PATCH of the sort

```json
{"redirect_uris":"https://[\"><script>alert()</script>"}
```

were causing server errors.

You could make the case that the `except` block here should just `raise` instead of this custom error. I'm indifferent, I just don't want the server error. We will monkey patch the validator until we can get this in a release.

Thanks!