### PR TITLE
Rename TokenHasMethodScopeAlternative to TokenMatchesOASRequirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * **Compatibility**: Python 3.4 is the new minimum required version.
 * **Compatibility**: Django 2.0 is the new minimum required version.
-* **New feature**: Added TokenHasMethodScopeAlternative Permissions.
+* **New feature**: Added TokenMatchesOASRequirements Permissions.
 
 ### 1.1.1 [2018-05-08]
 

--- a/docs/rest-framework/permissions.rst
+++ b/docs/rest-framework/permissions.rst
@@ -84,10 +84,10 @@ For example:
 The `required_scopes` attribute is mandatory.
 
 
-TokenHasMethodScopeAlternative
+TokenMatchesOASRequirements
 ------------------------------
 
-The `TokenHasMethodScopeAlternative` permission class allows the access based on a per-method basis
+The `TokenMatchesOASRequirements` permission class allows the access based on a per-method basis
 and with alternative lists of required scopes. This permission provides full functionality
 required by REST API specifications like the
 `OpenAPI Specification (OAS) security requirement object <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securityRequirementObject>`_.
@@ -102,7 +102,7 @@ etc.
 
     class SongView(views.APIView):
         authentication_classes = [OAuth2Authentication]
-        permission_classes = [TokenHasMethodScopeAlternative]
+        permission_classes = [TokenMatchesOASRequirements]
         required_alternate_scopes = {
             "GET": [["read"]],
             "POST": [["create"], ["post", "widget"]],

--- a/oauth2_provider/contrib/rest_framework/__init__.py
+++ b/oauth2_provider/contrib/rest_framework/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from .authentication import OAuth2Authentication
 from .permissions import (
-    TokenHasScope, TokenHasReadWriteScope, TokenHasMethodScopeAlternative,
+    TokenHasScope, TokenHasReadWriteScope, TokenMatchesOASRequirements,
     TokenHasResourceScope, IsAuthenticatedOrTokenHasScope
 )

--- a/oauth2_provider/contrib/rest_framework/permissions.py
+++ b/oauth2_provider/contrib/rest_framework/permissions.py
@@ -123,7 +123,7 @@ class IsAuthenticatedOrTokenHasScope(BasePermission):
         return (is_authenticated and not oauth2authenticated) or token_has_scope.has_permission(request, view)
 
 
-class TokenHasMethodScopeAlternative(BasePermission):
+class TokenMatchesOASRequirements(BasePermission):
     """
     :attr:alternate_required_scopes: dict keyed by HTTP method name with value: iterable alternate scope lists
 
@@ -165,7 +165,7 @@ class TokenHasMethodScopeAlternative(BasePermission):
                 log.warning("no scope alternates defined for method {0}".format(m))
                 return False
 
-        assert False, ("TokenHasMethodScope requires the"
+        assert False, ("TokenMatchesOASRequirements requires the"
                        "`oauth2_provider.rest_framework.OAuth2Authentication` authentication "
                        "class to be used.")
 
@@ -174,5 +174,5 @@ class TokenHasMethodScopeAlternative(BasePermission):
             return getattr(view, "required_alternate_scopes")
         except AttributeError:
             raise ImproperlyConfigured(
-                "TokenHasMethodScopeAlternative requires the view to"
+                "TokenMatchesOASRequirements requires the view to"
                 " define the required_alternate_scopes attribute")

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -14,8 +14,8 @@ from rest_framework.views import APIView
 
 from oauth2_provider.contrib.rest_framework import (
     IsAuthenticatedOrTokenHasScope, OAuth2Authentication,
-    TokenMatchesOASRequirements, TokenHasReadWriteScope,
-    TokenHasResourceScope, TokenHasScope
+    TokenHasReadWriteScope, TokenHasResourceScope,
+    TokenHasScope, TokenMatchesOASRequirements
 )
 from oauth2_provider.models import get_access_token_model, get_application_model
 from oauth2_provider.settings import oauth2_settings

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -14,7 +14,7 @@ from rest_framework.views import APIView
 
 from oauth2_provider.contrib.rest_framework import (
     IsAuthenticatedOrTokenHasScope, OAuth2Authentication,
-    TokenHasMethodScopeAlternative, TokenHasReadWriteScope,
+    TokenMatchesOASRequirements, TokenHasReadWriteScope,
     TokenHasResourceScope, TokenHasScope
 )
 from oauth2_provider.models import get_access_token_model, get_application_model
@@ -69,7 +69,7 @@ class ResourceScopedView(OAuth2View):
 
 
 class MethodScopeAltView(OAuth2View):
-    permission_classes = [TokenHasMethodScopeAlternative]
+    permission_classes = [TokenMatchesOASRequirements]
     required_alternate_scopes = {
         "GET": [["read"]],
         "POST": [["create"]],
@@ -79,7 +79,7 @@ class MethodScopeAltView(OAuth2View):
 
 
 class MethodScopeAltViewBad(OAuth2View):
-    permission_classes = [TokenHasMethodScopeAlternative]
+    permission_classes = [TokenMatchesOASRequirements]
 
 
 class MissingAuthentication(BaseAuthentication):
@@ -96,7 +96,7 @@ class TokenHasScopeViewWrongAuth(BrokenOAuth2View):
 
 
 class MethodScopeAltViewWrongAuth(BrokenOAuth2View):
-    permission_classes = [TokenHasMethodScopeAlternative]
+    permission_classes = [TokenMatchesOASRequirements]
 
 
 urlpatterns = [


### PR DESCRIPTION
See suggestion for a better name in #563