### PR TITLE
Ignoring requests containing list instead of dict

### DIFF
--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -180,7 +180,7 @@ class JSONOAuthLibCore(OAuthLibCore):
         """
         try:
             body = json.loads(request.body.decode("utf-8")).items()
-        except ValueError:
+        except AttributeError, ValueError:
             body = ""
 
         return body

--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -180,7 +180,9 @@ class JSONOAuthLibCore(OAuthLibCore):
         """
         try:
             body = json.loads(request.body.decode("utf-8")).items()
-        except AttributeError, ValueError:
+        except AttributeError:
+            body = ""
+        except ValueError:
             body = ""
 
         return body


### PR DESCRIPTION
If a request's body is a json list instead of a json object django-oauth-toolkit raises and exception. It breaks bulk requests for drf for example. This commit fixes it.