### PR TITLE
Fix 500 error for refresh with revoked access token.

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -625,6 +625,14 @@ class OAuth2Validator(RequestValidator):
         if not rt:
             return False
 
+        try:
+            # ensure access token was not revoked and later calls to get_original_scopes
+            # will not raise AccessToken.DoesNotExist.
+            if not rt.access_token_id:
+                AccessToken.objects.get(source_refresh_token_id=rt.id)
+        except AccessToken.DoesNotExist:
+            return False
+
         request.user = rt.user
         request.refresh_token = rt.token
         # Temporary store RefreshToken instance to be reused by get_original_scopes and save_bearer_token.


### PR DESCRIPTION
fixes #585

Note that there are no integration tests, so the unit tests don't
actually show the 500 error that would have been seen with a call
to oauth2_provider/oauth2_backends.py:create_token_response.

Also, there was no coverage for validate_refresh_token.  I added some coverage since I was updating it, but I did not add full coverage.