### PR TITLE
Fix issue for: "DoesNotExist: AccessToken matching query does not exist."

### DIFF
--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -8,6 +8,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic import FormView, View
+from django.db import transaction
 
 from ..exceptions import OAuthToolkitError
 from ..forms import AllowForm
@@ -201,6 +202,7 @@ class TokenView(OAuthLibMixin, View):
     validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
     oauthlib_backend_class = oauth2_settings.OAUTH2_BACKEND_CLASS
 
+    @transaction.atomic()
     @method_decorator(sensitive_post_parameters("password"))
     def post(self, request, *args, **kwargs):
         url, headers, body, status = self.create_token_response(request)


### PR DESCRIPTION
We had an issue where the AccessToken would be updated in db, but due to our master-slave(s) setup this would result in a DoesNotExist error. This fix resolves the issue.