### PR TITLE
Fix Refresh Token revocation when the access token does not exist

### DIFF
--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -377,7 +377,10 @@ class AbstractRefreshToken(models.Model):
             if not self:
                 return
 
-            access_token_model.objects.get(id=self.access_token_id).revoke()
+            try:
+                access_token_model.objects.get(id=self.access_token_id).revoke()
+            except access_token_model.DoesNotExist:
+                pass
             self.access_token = None
             self.revoked = timezone.now()
             self.save()


### PR DESCRIPTION
Fixes #625

----

Lands #629 on master for cherry-picking.