### PR TITLE
Fixing issue #631 - returning the refresh token of previous token

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -530,8 +530,8 @@ class OAuth2Validator(RequestValidator):
                 else:
                     # make sure that the token data we're returning matches
                     # the existing token
-                    token["refresh_token"] = previous_access_token.refresh_token.token
                     token["access_token"] = previous_access_token.token
+                    token["refresh_token"] = previous_access_token.source_refresh_token.token
                     token["scope"] = previous_access_token.scope
 
         # No refresh token should be created, just access token

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -530,6 +530,7 @@ class OAuth2Validator(RequestValidator):
                 else:
                     # make sure that the token data we're returning matches
                     # the existing token
+                    token["refresh_token"] = previous_access_token.refresh_token.token
                     token["access_token"] = previous_access_token.token
                     token["scope"] = previous_access_token.scope
 

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -636,6 +636,7 @@ class TestAuthorizationCodeTokenView(BaseTest):
             "refresh_token": content["refresh_token"],
             "scope": content["scope"],
         }
+        refresh_token = content["refresh_token"]
         response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
         self.assertEqual(response.status_code, 200)
 
@@ -643,12 +644,15 @@ class TestAuthorizationCodeTokenView(BaseTest):
         self.assertTrue("access_token" in content)
         first_access_token = content["access_token"]
 
-        # check refresh token returns same data if used twice, see #497
+        # check access token returns same data if used twice, see #497
         response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content.decode("utf-8"))
         self.assertTrue("access_token" in content)
         self.assertEqual(content["access_token"], first_access_token)
+        # refresh token should be the same as well
+        self.assertTrue("refresh_token" in content)
+        self.assertEqual(content["refresh_token"], refresh_token)
         oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = 0
 
     def test_refresh_invalidates_old_tokens(self):


### PR DESCRIPTION
adding the 'refresh_token' to the dictionary being returned when the refresh_token is being reused.