### PR TITLE
Pin oauthlib to avoid breakage with 3.0.0 release.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ include_package_data = True
 zip_safe = False
 install_requires =
 	django >= 2.0
-	oauthlib >= 2.0.3
+	oauthlib >= 2.0.3, < 3.0.0
 	requests >= 2.13.0
 
 [options.packages.find]


### PR DESCRIPTION
We're going to release OAuthLib 3.0.0 soon, which contains some breaking changes.

This pinpoint is to avoid problems before we are able to address the compatibility.