### PR TITLE
Add hook for creating custom refresh tokens

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -520,13 +520,7 @@ class OAuth2Validator(RequestValidator):
                         source_refresh_token=refresh_token_instance,
                     )
 
-                    refresh_token = RefreshToken(
-                        user=request.user,
-                        token=refresh_token_code,
-                        application=request.client,
-                        access_token=access_token
-                    )
-                    refresh_token.save()
+                    self._create_refresh_token(request, refresh_token_code, access_token)
                 else:
                     # make sure that the token data we're returning matches
                     # the existing token
@@ -552,6 +546,15 @@ class OAuth2Validator(RequestValidator):
         )
         access_token.save()
         return access_token
+
+    def _create_refresh_token(self, request, refresh_token_code, access_token):
+        refresh_token = RefreshToken(
+            user=request.user,
+            token=refresh_token_code,
+            application=request.client,
+            access_token=access_token
+        )
+        refresh_token.save()
 
     def revoke_token(self, token, token_type_hint, request, *args, **kwargs):
         """

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -270,6 +270,23 @@ class TestOAuth2Validator(TransactionTestCase):
         self.assertEqual(0, RefreshToken.objects.count())
         self.assertEqual(1, AccessToken.objects.count())
 
+    def test_save_bearer_token__with_new_token__calls_methods_to_create_access_and_refresh_tokens(self):
+        token = {
+            "scope": "foo bar",
+            "refresh_token": "abc",
+            "access_token": "123",
+        }
+        # Mock private methods to create access and refresh tokens
+        create_access_token_mock = mock.MagicMock()
+        create_refresh_token_mock = mock.MagicMock()
+        self.validator._create_refresh_token = create_refresh_token_mock
+        self.validator._create_access_token = create_access_token_mock
+
+        self.validator.save_bearer_token(token, self.request)
+
+        create_access_token_mock.assert_called_once()
+        create_refresh_token_mock.asert_called_once()
+
 
 class TestOAuth2ValidatorProvidesErrorData(TransactionTestCase):
     """These test cases check that the recommended error codes are returned


### PR DESCRIPTION
In our project we have a custom attribute on refresh token that we need to inject when creating those, for now we have the entire method save_beaer_token duplicated when we need only this bit. I thought that since there is already something similar for the AccessToken maybe the same path could be applied for RefreshToken