### PR TITLE
Return the new refresh token during grace period (#702)

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -551,7 +551,9 @@ class OAuth2Validator(RequestValidator):
                     # make sure that the token data we're returning matches
                     # the existing token
                     token["access_token"] = previous_access_token.token
-                    token["refresh_token"] = previous_access_token.source_refresh_token.token
+                    token["refresh_token"] = RefreshToken.objects.filter(
+                        access_token=previous_access_token
+                    ).first().token
                     token["scope"] = previous_access_token.scope
 
         # No refresh token should be created, just access token

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -672,13 +672,14 @@ class TestAuthorizationCodeTokenView(BaseTest):
             "refresh_token": content["refresh_token"],
             "scope": content["scope"],
         }
-        refresh_token = content["refresh_token"]
+
         response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
         self.assertEqual(response.status_code, 200)
 
         content = json.loads(response.content.decode("utf-8"))
         self.assertTrue("access_token" in content)
         first_access_token = content["access_token"]
+        first_refresh_token = content["refresh_token"]
 
         # check access token returns same data if used twice, see #497
         response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
@@ -688,7 +689,7 @@ class TestAuthorizationCodeTokenView(BaseTest):
         self.assertEqual(content["access_token"], first_access_token)
         # refresh token should be the same as well
         self.assertTrue("refresh_token" in content)
-        self.assertEqual(content["refresh_token"], refresh_token)
+        self.assertEqual(content["refresh_token"], first_refresh_token)
         oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = 0
 
     def test_refresh_invalidates_old_tokens(self):


### PR DESCRIPTION
Returns the new refresh token from the refresh_token endpoint instead of the old, revoked one during grace period.

Resolves #702.