### PR TITLE
Fix PKCE credentials not being captured during authorize requests

### DIFF
--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -32,6 +32,7 @@ class BaseAuthorizationView(LoginRequiredMixin, OAuthLibMixin, View):
     * Implicit grant
 
     """
+
     def dispatch(self, request, *args, **kwargs):
         self.oauth2_data = {}
         return super().dispatch(request, *args, **kwargs)
@@ -132,6 +133,8 @@ class AuthorizationView(BaseAuthorizationView, FormView):
     def get(self, request, *args, **kwargs):
         try:
             scopes, credentials = self.validate_authorization_request(request)
+            credentials["code_challenge"] = request.GET.get("code_challenge", None)
+            credentials["code_challenge_method"] = request.GET.get("code_challenge_method", None)
         except OAuthToolkitError as error:
             # Application is not available at this time.
             return self.error_response(error, application=None)
@@ -149,8 +152,8 @@ class AuthorizationView(BaseAuthorizationView, FormView):
         kwargs["redirect_uri"] = credentials["redirect_uri"]
         kwargs["response_type"] = credentials["response_type"]
         kwargs["state"] = credentials["state"]
-        kwargs["code_challenge"] = credentials.get("code_challenge", None)
-        kwargs["code_challenge_method"] = credentials.get("code_challenge_method", None)
+        kwargs["code_challenge"] = credentials["code_challenge"]
+        kwargs["code_challenge_method"] = credentials["code_challenge_method"]
 
         self.oauth2_data = kwargs
         # following two loc are here only because of https://code.djangoproject.com/ticket/17795

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -133,8 +133,16 @@ class AuthorizationView(BaseAuthorizationView, FormView):
     def get(self, request, *args, **kwargs):
         try:
             scopes, credentials = self.validate_authorization_request(request)
-            credentials["code_challenge"] = request.GET.get("code_challenge", None)
-            credentials["code_challenge_method"] = request.GET.get("code_challenge_method", None)
+            # TODO: Remove the two following lines after oauthlib updates its implementation
+            # https://github.com/jazzband/django-oauth-toolkit/pull/707#issuecomment-485011945
+            credentials["code_challenge"] = credentials.get(
+                "code_challenge",
+                request.GET.get("code_challenge", None)
+            )
+            credentials["code_challenge_method"] = credentials.get(
+                "code_challenge_method",
+                request.GET.get("code_challenge_method", None)
+            )
         except OAuthToolkitError as error:
             # Application is not available at this time.
             return self.error_response(error, application=None)

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -1072,9 +1072,6 @@ class TestAuthorizationCodeTokenView(BaseTest):
         url = "{url}?{qs}".format(url=reverse("oauth2_provider:authorize"), qs=query_string)
 
         response = self.client.get(url)
-        print(code_challenge)
-        print(response.context_data)
-        print(url)
         self.assertEqual(response.status_code, 200)
         oauth2_settings.PKCE_REQUIRED = False
 
@@ -1130,7 +1127,6 @@ class TestAuthorizationCodeTokenView(BaseTest):
         }
 
         response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data)
-        print(response.content)
         self.assertEqual(response.status_code, 200)
 
         content = json.loads(response.content.decode("utf-8"))


### PR DESCRIPTION
PKCE credentials are not being captured during GET authorize requests. oauthlib should(?) return `code_challenge` and `code_challenge_method` from [grant_types.authorization_code.validate_authorization_request](https://github.com/oauthlib/oauthlib/blob/master/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py#L318).

@JonathanHuot, if oauthlib does not return them, clients using oauthlib must capture them manually. Is that intended?