### PR TITLE
Use getattr for oauth2_error access (#633)

### DIFF
--- a/oauth2_provider/contrib/rest_framework/authentication.py
+++ b/oauth2_provider/contrib/rest_framework/authentication.py
@@ -39,7 +39,8 @@ class OAuth2Authentication(BaseAuthentication):
         www_authenticate_attributes = OrderedDict([
             ("realm", self.www_authenticate_realm,),
         ])
-        www_authenticate_attributes.update(request.oauth2_error)
+        oauth2_error = getattr(request, "oauth2_error", {})
+        www_authenticate_attributes.update(oauth2_error)
         return "Bearer {attributes}".format(
             attributes=self._dict_to_string(www_authenticate_attributes),
         )


### PR DESCRIPTION
If the request doesn't have a oauth2_error property the
authenticate_header method errors. This can happen when the
oauthlib_core.verify_request method raises exceptions in authenticate.
It is useful to be able to raise AuthenticationFailed exceptions from
within a custom validate_bearer_token method which causes this.