### PR TITLE
Authenticate is supposed to take the request in param

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -611,7 +611,7 @@ class OAuth2Validator(RequestValidator):
         """
         Check username and password correspond to a valid and active User
         """
-        u = authenticate(username=username, password=password)
+        u = authenticate(request, username=username, password=password)
         if u is not None and u.is_active:
             request.user = u
             return True


### PR DESCRIPTION
Sometimes the request is needed (for audit tracking of logging attempts for example)

https://github.com/django/django/blob/4116b369b191f1830bbe761fa7fb29bf1becc8ef/django/contrib/auth/backends.py#L16
https://docs.djangoproject.com/en/2.2/topics/auth/customizing/#writing-an-authentication-backend