### PR TITLE
Updated 'url' with 'path' in documentation

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -21,7 +21,10 @@ If you need an OAuth2 provider you'll want to add the following to your urls.py
 
     urlpatterns = [
         ...
-        url(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+        path('o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+
+        # using re_path
+        re_path(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     ]
 
 Sync your database

--- a/docs/tutorial/tutorial_01.rst
+++ b/docs/tutorial/tutorial_01.rst
@@ -34,8 +34,8 @@ Include the Django OAuth Toolkit urls in your `urls.py`, choosing the urlspace y
 .. code-block:: python
 
     urlpatterns = [
-        url(r"^admin/", admin.site.urls),
-        url(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+        path("admin", admin.site.urls),
+        path("o/", include('oauth2_provider.urls', namespace='oauth2_provider')),
         # ...
     ]
 

--- a/docs/tutorial/tutorial_02.rst
+++ b/docs/tutorial/tutorial_02.rst
@@ -41,32 +41,32 @@ URL this view will respond to:
 
     # OAuth2 provider endpoints
     oauth2_endpoint_views = [
-        url(r'^authorize/$', oauth2_views.AuthorizationView.as_view(), name="authorize"),
-        url(r'^token/$', oauth2_views.TokenView.as_view(), name="token"),
-        url(r'^revoke-token/$', oauth2_views.RevokeTokenView.as_view(), name="revoke-token"),
+        path('authorize/', oauth2_views.AuthorizationView.as_view(), name="authorize"),
+        path('token/', oauth2_views.TokenView.as_view(), name="token"),
+        path('revoke-token/', oauth2_views.RevokeTokenView.as_view(), name="revoke-token"),
     ]
 
     if settings.DEBUG:
         # OAuth2 Application Management endpoints
         oauth2_endpoint_views += [
-            url(r'^applications/$', oauth2_views.ApplicationList.as_view(), name="list"),
-            url(r'^applications/register/$', oauth2_views.ApplicationRegistration.as_view(), name="register"),
-            url(r'^applications/(?P<pk>\d+)/$', oauth2_views.ApplicationDetail.as_view(), name="detail"),
-            url(r'^applications/(?P<pk>\d+)/delete/$', oauth2_views.ApplicationDelete.as_view(), name="delete"),
-            url(r'^applications/(?P<pk>\d+)/update/$', oauth2_views.ApplicationUpdate.as_view(), name="update"),
+            path('applications/', oauth2_views.ApplicationList.as_view(), name="list"),
+            path('applications/register/', oauth2_views.ApplicationRegistration.as_view(), name="register"),
+            path('applications/<pk>/', oauth2_views.ApplicationDetail.as_view(), name="detail"),
+            path('applications/<pk>/delete/', oauth2_views.ApplicationDelete.as_view(), name="delete"),
+            path('applications/<pk>/update/', oauth2_views.ApplicationUpdate.as_view(), name="update"),
         ]
 
         # OAuth2 Token Management endpoints
         oauth2_endpoint_views += [
-            url(r'^authorized-tokens/$', oauth2_views.AuthorizedTokensListView.as_view(), name="authorized-token-list"),
-            url(r'^authorized-tokens/(?P<pk>\d+)/delete/$', oauth2_views.AuthorizedTokenDeleteView.as_view(),
+            path('authorized-tokens/', oauth2_views.AuthorizedTokensListView.as_view(), name="authorized-token-list"),
+            path('authorized-tokens/<pk>/delete/', oauth2_views.AuthorizedTokenDeleteView.as_view(),
                 name="authorized-token-delete"),
         ]
 
     urlpatterns = [
         # OAuth 2 endpoints:
-        url(r'^o/', include(oauth2_endpoint_views, namespace="oauth2_provider")),
-        url(r'^api/hello', ApiEndpoint.as_view()),  # an example resource endpoint
+        path('o/', include(oauth2_endpoint_views, namespace="oauth2_provider")),
+        path('api/hello', ApiEndpoint.as_view()),  # an example resource endpoint
     ]
 
 You will probably want to write your own application views to deal with permissions and access control but the ones packaged with the library can get you started when developing the app.

--- a/docs/tutorial/tutorial_03.rst
+++ b/docs/tutorial/tutorial_03.rst
@@ -74,7 +74,7 @@ To check everything works properly, mount the view above to some url:
 .. code-block:: python
 
     urlpatterns = [
-        url(r'^secret$', 'my.views.secret_page', name='secret'),
+        path('secret', 'my.views.secret_page', name='secret'),
         '...',
     ]
 


### PR DESCRIPTION
* Updated install.rst, tutorial_01, tutorial_02, and tutorial_03 to use 'path' instead of 'url' for urlpatterns.