### PR TITLE
Add id in list_display on AplicationAdmin.

### DIFF
--- a/oauth2_provider/admin.py
+++ b/oauth2_provider/admin.py
@@ -7,7 +7,7 @@ from .models import (
 
 
 class ApplicationAdmin(admin.ModelAdmin):
-    list_display = ("name", "user", "client_type", "authorization_grant_type")
+    list_display = ("id", "name", "user", "client_type", "authorization_grant_type")
     list_filter = ("client_type", "authorization_grant_type", "skip_authorization")
     radio_fields = {
         "client_type": admin.HORIZONTAL,


### PR DESCRIPTION
Hello,

I added id field in list_display because, when create a application register without name, this item stay without link to click to change it.