### PR TITLE
Remove Django 3.0 DeprecationWarning

### DIFF
--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models, transaction
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .generators import generate_client_id, generate_client_secret
 from .scopes import get_scopes_backend

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -13,7 +13,7 @@ from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.timezone import make_aware
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from oauthlib.oauth2 import RequestValidator
 
 from .exceptions import FatalClientError


### PR DESCRIPTION
Change ugettext_lazy by gettext_lazy to remove Django 3.0 DeprecationWarning

- Log Sample:

```shell
.../lib/python3.7/site-packages/oauth2_provider/models.py:41: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  (CLIENT_CONFIDENTIAL, _("Confidential")),
.../lib/python3.7/site-packages/oauth2_provider/models.py:42: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  (CLIENT_PUBLIC, _("Public")),
.../lib/python3.7/site-packages/oauth2_provider/models.py:50: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  (GRANT_AUTHORIZATION_CODE, _("Authorization code")),
.../lib/python3.7/site-packages/oauth2_provider/models.py:51: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  (GRANT_IMPLICIT, _("Implicit")),
.../lib/python3.7/site-packages/oauth2_provider/models.py:52: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  (GRANT_PASSWORD, _("Resource owner password-based")),
.../lib/python3.7/site-packages/oauth2_provider/models.py:53: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  (GRANT_CLIENT_CREDENTIALS, _("Client credentials")),
.../lib/python3.7/site-packages/oauth2_provider/models.py:67: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  blank=True, help_text=_("Allowed URIs list, space separated"),
```