### PR TITLE
Reduce detail page load time in admin site for access tokens

### DIFF
--- a/oauth2_provider/admin.py
+++ b/oauth2_provider/admin.py
@@ -23,7 +23,7 @@ class GrantAdmin(admin.ModelAdmin):
 
 class AccessTokenAdmin(admin.ModelAdmin):
     list_display = ("token", "user", "application", "expires")
-    raw_id_fields = ("user", )
+    raw_id_fields = ("user", "source_refresh_token")
 
 
 class RefreshTokenAdmin(admin.ModelAdmin):


### PR DESCRIPTION
This PR adds `source_refresh_token` to `raw_id_fields` within `AccessTokenAdmin` to significantly reduce the time it takes to load the detail view of any access token inside the admin site when there are a large number of refresh tokens.

This should resolve #777.