### PR TITLE
Fix template one changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,5 +8,4 @@ Fixes #
 - [ ] unit-test added
 - [ ] documentation updated
 - [ ] `CHANGELOG.md` updated (only for user relevant changes)
-- [ ] `docs/changelog.rst` updated to match.
 - [ ] author name in `AUTHORS`

--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Contributors
 ============
 
 Alessandro De Angelis
+Alan Crosswell
 Asif Saif Uddin
 Ash Christopher
 Aristóbulo Meneses


### PR DESCRIPTION
Fixes #

## Description of the Change
Now that we have a single changelog (#791), there is no need to update docs/changelog.rst.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] ~`docs/changelog.rst` updated to match.~
- [x] author name in `AUTHORS`
