### PR TITLE
document undocumented PRs 1.2.0 -> 1.3.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+Fixes #
+
+## Description of the Change
+
+## Checklist
+
+- [ ] PR only contains one change (considered splitting up PR)
+- [ ] unit-test added
+- [ ] documentation updated
+- [ ] `CHANGELOG.md` updated (only for user relevant changes)
+- [ ] `docs/changelog.rst` updated to match.
+- [ ] author name in `AUTHORS`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Add support for Python 3.7 & 3.8
-* Add support for Django>=2.1,<=3.0
+* Add support for Django>=2.1,<3.1
 * Add requirement for oauthlib>=3.0.1
 * Add support for [Proof Key for Code Exchange (PKCE, RFC 7636)](https://tools.ietf.org/html/rfc7636).
 * Add support for custom token generators (e.g. to create JWT tokens).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,64 @@
-## Changelog
-### 1.3.0 [unreleased]
+# Changelog
+All notable changes to this project will be documented in this file.
 
-* Fix a race condition in creation of AccessToken with external oauth2 server.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [unreleased]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## [1.3.0] 2020-03-TBD
+
+### Added
+* Add support for Python 3.7 & 3.8
+* Add support for Django>=2.1,<=3.0
+* Add requirement for oauthlib>=3.0.1
+* Add support for [Proof Key for Code Exchange (PKCE, RFC 7636)](https://tools.ietf.org/html/rfc7636).
+* Add support for custom token generators (e.g. to create JWT tokens).
+* Add new `OAUTH2_PROVIDER` [settings](https://django-oauth-toolkit.readthedocs.io/en/latest/settings.html):
+  - `ACCESS_TOKEN_GENERATOR` to override the default access token generator.
+  - `REFRESH_TOKEN_GENERATOR` to override the default refresh token generator.
+  - `EXTRA_SERVER_KWARGS` options dictionary for oauthlib's Server class.
+  - `PKCE_REQUIRED` to require PKCE.
+* Add `createapplication` management command to create an application.
+* Add `id` in toolkit admin console applications list.
+* Add nonstandard Google support for [urn:ietf:wg:oauth:2.0:oob] `redirect_uri`
+  for [Google OAuth2](https://developers.google.com/identity/protocols/OAuth2InstalledApp) "manual copy/paste".
+  **N.B.** this feature appears to be deprecated and replaced with methods described in
+  [RFC 8252: OAuth2 for Native Apps](https://tools.ietf.org/html/rfc8252) and *may* be deprecated and/or removed
+  from a future release of Django-oauth-toolkit.
+
+### Changed
+* Change this change log to use [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 * **Backwards-incompatible** squashed migrations:
-  If you are currently on a release < 1.2.0, you will need to first install 1.2.x then `manage.py migrate` before
+  If you are currently on a release < 1.2.0, you will need to first install 1.2.0 then `manage.py migrate` before
   upgrading to >= 1.3.0.
-* Bump django minimum to 2.1
-* Dropped Python 3.4
+* Improved the [tutorial](https://django-oauth-toolkit.readthedocs.io/en/latest/tutorial/tutorial.html).
 
-### 1.2.0 [2018-06-03]
+### Removed
+* Remove support for Python 3.4
+* Remove support for Django<=2.0
+* Remove requirement for oauthlib<3.0
+
+### Fixed
+* Fix a race condition in creation of AccessToken with external oauth2 server.
+* Fix several concurrency issues. (#[638](https://github.com/jazzband/django-oauth-toolkit/issues/638))
+* Fix to pass `request` to `django.contrib.auth.authenticate()` (#[636](https://github.com/jazzband/django-oauth-toolkit/issues/636))
+* Fix missing `oauth2_error` property exception oauthlib_core.verify_request method raises exceptions in authenticate.
+  (#[633](https://github.com/jazzband/django-oauth-toolkit/issues/633))
+* Fix "django.db.utils.NotSupportedError: FOR UPDATE cannot be applied to the nullable side of an outer join" for postgresql.
+  (#[714](https://github.com/jazzband/django-oauth-toolkit/issues/714))
+* Fix to return a new refresh token during grace period rather than the recently-revoked one.
+  (#[702](https://github.com/jazzband/django-oauth-toolkit/issues/702))
+* Fix a bug in refresh token revocation.
+  (#[625](https://github.com/jazzband/django-oauth-toolkit/issues/625))
+
+## 1.2.0 [2018-06-03]
 
 * **Compatibility**: Python 3.4 is the new minimum required version.
 * **Compatibility**: Django 2.0 is the new minimum required version.
@@ -17,13 +67,13 @@
 * Moved `redirect_uris` validation to the application clean() method.
 
 
-### 1.1.2 [2018-05-12]
+## 1.1.2 [2018-05-12]
 
 * Return state with Authorization Denied error (RFC6749 section 4.1.2.1)
 * Fix a crash with malformed base64 authentication headers
 * Fix a crash with malformed IPv6 redirect URIs
 
-### 1.1.1 [2018-05-08]
+## 1.1.1 [2018-05-08]
 
 * **Critical**: Django OAuth Toolkit 1.1.0 contained a migration that would revoke all existing
   RefreshTokens (`0006_auto_20171214_2232`). This release corrects the migration.
@@ -31,7 +81,7 @@
   https://github.com/jazzband/django-oauth-toolkit/issues/589
 
 
-### 1.1.0 [2018-04-13]
+## 1.1.0 [2018-04-13]
 
 * **Notice**: The Django OAuth Toolkit project is now hosted by JazzBand.
 * **Compatibility**: Django 1.11 is the new minimum required version. Django 1.10 is no longer supported.
@@ -45,7 +95,7 @@
   refresh tokens may be re-used.
 * An `app_authorized` signal is fired when a token is generated.
 
-### 1.0.0 [2017-06-07]
+## 1.0.0 [2017-06-07]
 
 * **New feature**: AccessToken, RefreshToken and Grant models are now swappable.
 * #477: **New feature**: Add support for RFC 7662 (IntrospectTokenView, introspect scope)
@@ -61,7 +111,7 @@
 * The dependency on django-braces has been dropped.
 * The oauthlib dependency is no longer pinned.
 
-### 0.12.0 [2017-02-24]
+## 0.12.0 [2017-02-24]
 
 * **New feature**: Class-based scopes backends. Listing scopes, available scopes and default scopes
   is now done through the class that the `SCOPES_BACKEND_CLASS` setting points to.
@@ -75,7 +125,7 @@
 * #434: Relax URL patterns to allow for UUID primary keys
 
 
-### 0.11.0 [2016-12-1]
+## 0.11.0 [2016-12-1]
 
 * #315: AuthorizationView does not overwrite requests on get
 * #425: Added support for Django 1.10
@@ -84,7 +134,7 @@
 * #389: Reuse refresh tokens if enabled.
 
 
-### 0.10.0 [2015-12-14]
+## 0.10.0 [2015-12-14]
 
 * **#322: dropping support for python 2.6 and django 1.4, 1.5, 1.6**
 * #310: Fixed error that could occur sometimes when checking validity of incomplete AccessToken/Grant
@@ -101,7 +151,7 @@
 * #273: Generic read write scope by resource
 
 
-### 0.9.0 [2015-07-28]
+## 0.9.0 [2015-07-28]
 
 * ``oauthlib_backend_class`` is now pluggable through Django settings
 * #127: ``application/json`` Content-Type is now supported using ``JSONOAuthLibCore``
@@ -110,15 +160,15 @@
 * added support for oauthlib 1.0
 
 
-### 0.8.2 [2015-06-25]
+## 0.8.2 [2015-06-25]
 
 * Fix the migrations to be two-step and allow upgrade from 0.7.2
 
-### 0.8.1 [2015-04-27]
+## 0.8.1 [2015-04-27]
 
 * South migrations fixed. Added new django migrations.
 
-### 0.8.0 [2015-03-27]
+## 0.8.0 [2015-03-27]
 
 * Several docs improvements and minor fixes
 * #185: fixed vulnerabilities on Basic authentication
@@ -136,17 +186,17 @@
 * #38: create access tokens not bound to a user instance for *client credentials* flow
 
 
-### 0.7.2 [2014-07-02]
+## 0.7.2 [2014-07-02]
 
 * Don't pin oauthlib
 
-### 0.7.1 [2014-04-27]
+## 0.7.1 [2014-04-27]
 
 * Added database indexes to the OAuth2 related models to improve performances.
 
 **Warning: schema migration does not work for sqlite3 database, migration should be performed manually**
 
-### 0.7.0 [2014-03-01]
+## 0.7.0 [2014-03-01]
 
 * Created a setting for the default value for approval prompt.
 * Improved docs
@@ -157,12 +207,12 @@
 * Make Application model truly "swappable" (introduces a new non-namespaced setting `OAUTH2_PROVIDER_APPLICATION_MODEL`)
 
 
-### 0.6.1 [2014-02-05]
+## 0.6.1 [2014-02-05]
 
 * added support for `scope` query parameter keeping backwards compatibility for the original `scopes` parameter.
 * __str__ method in Application model returns content of `name` field when available
 
-### 0.6.0 [2014-01-26]
+## 0.6.0 [2014-01-26]
 
 * oauthlib 0.6.1 support
 * Django dev branch support
@@ -178,7 +228,7 @@
 * Issue #64: Fix urlencode clientid secret
 
 
-### 0.5.0 [2013-09-17]
+## 0.5.0 [2013-09-17]
 
 * oauthlib 0.6.0 support
 
@@ -195,11 +245,11 @@
 * Issue #53: Quote characters in the url query that are safe for Django but not for oauthlib
 
 
-### 0.4.1 [2013-09-06]
+## 0.4.1 [2013-09-06]
 
 * Optimize queries on access token validation
 
-### 0.4.0 [2013-08-09]
+## 0.4.0 [2013-08-09]
 
 **New Features**
 
@@ -229,15 +279,15 @@
 * Issue #47: Add docs for views decorators
 
 
-### 0.3.2 [2013-07-10]
+## 0.3.2 [2013-07-10]
 
 * Bugfix #37: Error in migrations with custom user on Django 1.5
 
-### 0.3.1 [2013-07-10]
+## 0.3.1 [2013-07-10]
 
 * Bugfix #27: OAuthlib refresh token refactoring
 
-### 0.3.0 [2013-06-14]
+## 0.3.0 [2013-06-14]
 
 * [Django REST Framework](http://django-rest-framework.org/) integration layer
 * Bugfix #13: Populate request with client and user in `validate_bearer_token`
@@ -248,11 +298,11 @@
 * `requested_scopes` parameter in ScopedResourceMixin changed to `required_scopes`
 
 
-### 0.2.1 [2013-06-06]
+## 0.2.1 [2013-06-06]
 
 * Core optimizations
 
-### 0.2.0 [2013-06-05]
+## 0.2.0 [2013-06-05]
 
 * Add support for Django1.4 and Django1.6
 * Add support for Python 3.3
@@ -260,12 +310,12 @@
 * Add tutorial to docs
 
 
-### 0.1.0 [2013-05-31]
+## 0.1.0 [2013-05-31]
 
 * Support OAuth2 Authorization Flows
 
 
-### 0.0.0 [2013-05-17]
+## 0.0.0 [2013-05-17]
 
 * Discussion with Daniel Greenfeld at Django Circus
 * Ignition


### PR DESCRIPTION
Fixes #

## Description of the Change
Adds descriptions of previously undocumented merged PRs (based on reading the
commit history, PRs, issues). Switches over to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) style.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
