### PR TITLE
Restore djangomaster tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,51 @@ dist: bionic
 
 language: python
 
-python:
-  - "3.8"
-  - "3.7"
-  - "3.6"
-  - "3.5"
-
 cache:
   directories:
     - $HOME/.cache/pip
     - $TRAVIS_BUILD_DIR/.tox
+
+# Make sure to coordinate changes to envlist in tox.ini.
+matrix:
+  allow_failures:
+    - env: TOXENV=py36-djangomaster
+    - env: TOXENV=py37-djangomaster      
+    - env: TOXENV=py38-djangomaster
+
+  include:
+    - python: 3.7
+      env: TOXENV=py37-flake8
+    - python: 3.7
+      env: TOXENV=py37-docs
+
+    - python: 3.8
+      env: TOXENV=py38-django30
+    - python: 3.8
+      env: TOXENV=py38-django22
+    - python: 3.8
+      env: TOXENV=py38-django21
+    - python: 3.8
+      env: TOXENV=py38-djangomaster
+
+    - python: 3.7
+      env: TOXENV=py37-django30
+    - python: 3.7
+      env: TOXENV=py37-django22
+    - python: 3.7
+      env: TOXENV=py37-django21
+    - python: 3.7
+      env: TOXENV=py37-djangomaster
+
+    - python: 3.6
+      env: TOXENV=py36-django22
+    - python: 3.6
+      env: TOXENV=py36-django21
+
+    - python: 3.5
+      env: TOXENV=py35-django22
+    - python: 3.5
+      env: TOXENV=py35-django21
 
 install:
   - pip install coveralls tox tox-travis

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,9 @@ envlist =
 	py37-django{30,22,21},
 	py36-django{22,21},
 	py35-django{22,21},
-# FIXME: something is broken in DRF integration, enable once fixed
-#	py38-djangomaster,
-#	py37-djangomaster,
-#	py36-djangomaster,
+	py38-djangomaster,
+	py37-djangomaster,
+	py36-djangomaster,
 
 [pytest]
 django_find_project = false
@@ -51,6 +50,7 @@ commands =
 deps =
 	flake8
 	flake8-isort
+# TODO: restore this:
 #	flake8-quotes
 
 [coverage:run]


### PR DESCRIPTION
Fixes #

## Description of the Change
Restores commented-out tox tests.
Converts travis to explicit matrix to enable allowed failing tests against django master.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
