### PR TITLE
sync up requirements documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,7 @@ Requirements
 
 * Python 3.5+
 * Django 2.1+
+* oauthlib 3.0+
 
 Installation
 ------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,8 +21,9 @@ If you need support please send a message to the `Django OAuth Toolkit Google Gr
 Requirements
 ------------
 
-* Python 3.4+
-* Django 2.0+
+* Python 3.5+
+* Django 2.1+
+* oauthlib 3.0+
 
 Index
 =====


### PR DESCRIPTION
Fixes #

## Description of the Change
Documentation update: Make it clear that oauthlib>=3.0 is required since we were previously pinned <3.0.

See #785 

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
