### PR TITLE
bump the version to 1.3.2 to allow fixing an incorrect twine upload of 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
   -->
 
+## [1.3.2] 2020-03-24
+
+### Fixed
+* Fixes: 1.3.1 inadvertently uploaded to pypi with an extra migration (0003...) from a dev branch.
+
 ## [1.3.1] 2020-03-23
 
 ### Added

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-oauth-toolkit
-version = 1.3.1
+version = 1.3.2
 description = OAuth2 Provider for Django
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
Fixes #819 

## Description of the Change

No code changes here but a [new version is required by pypi](https://pypi.org/help/#file-name-reuse) due to inadvertently packaging an extra migration that was laying around from a dev branch.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
