### PR TITLE
pkce in oauthlib 3.1.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Requirements
 
 * Python 3.5+
 * Django 2.1+
-* oauthlib 3.0+
+* oauthlib 3.1+
 
 Installation
 ------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Requirements
 
 * Python 3.5+
 * Django 2.1+
-* oauthlib 3.0+
+* oauthlib 3.1+
 
 Index
 =====

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 Django>=3.0,<3.1
-oauthlib>=3.0.1
+oauthlib>=3.1.0
 m2r>=0.2.1
 .

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -139,16 +139,6 @@ class AuthorizationView(BaseAuthorizationView, FormView):
     def get(self, request, *args, **kwargs):
         try:
             scopes, credentials = self.validate_authorization_request(request)
-            # TODO: Remove the two following lines after oauthlib updates its implementation
-            # https://github.com/jazzband/django-oauth-toolkit/pull/707#issuecomment-485011945
-            credentials["code_challenge"] = credentials.get(
-                "code_challenge",
-                request.GET.get("code_challenge", None)
-            )
-            credentials["code_challenge_method"] = credentials.get(
-                "code_challenge_method",
-                request.GET.get("code_challenge_method", None)
-            )
         except OAuthToolkitError as error:
             # Application is not available at this time.
             return self.error_response(error, application=None)

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -156,8 +156,6 @@ class AuthorizationView(BaseAuthorizationView, FormView):
         kwargs["redirect_uri"] = credentials["redirect_uri"]
         kwargs["response_type"] = credentials["response_type"]
         kwargs["state"] = credentials["state"]
-        kwargs["code_challenge"] = credentials["code_challenge"]
-        kwargs["code_challenge_method"] = credentials["code_challenge_method"]
 
         self.oauth2_data = kwargs
         # following two loc are here only because of https://code.djangoproject.com/ticket/17795

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ zip_safe = False
 install_requires =
 	django >= 2.1
 	requests >= 2.13.0
-	oauthlib >= 3.0.1
+	oauthlib >= 3.1.0
 
 [options.packages.find]
 exclude = tests

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ basepython = python
 changedir = docs
 whitelist_externals = make
 commands = make html
-deps = sphinx<3.0.0
+deps = sphinx<3
        oauthlib>=3.1.0
        m2r>=0.2.1
 

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ basepython = python
 changedir = docs
 whitelist_externals = make
 commands = make html
-deps = sphinx
+deps = sphinx<3.0.0
        oauthlib>=3.1.0
        m2r>=0.2.1
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
 	django30: Django>=3.0,<3.1
 	djangomaster: https://github.com/django/django/archive/master.tar.gz
 	djangorestframework
-	oauthlib>=3.0.1
+	oauthlib>=3.1.0
 	coverage
 	pytest
 	pytest-cov
@@ -40,7 +40,7 @@ changedir = docs
 whitelist_externals = make
 commands = make html
 deps = sphinx
-       oauthlib>=3.0.1
+       oauthlib>=3.1.0
        m2r>=0.2.1
 
 [testenv:py37-flake8]


### PR DESCRIPTION
## Description of the Change

OAuthLib landed PKCE support in 3.1.0 version via https://github.com/oauthlib/oauthlib/pull/671. Therefore there is no need for work-around in django-oauth-toolkit.

Docs where failing due to m2r lacks compatibility with sphinx 3.x, so had to specify sphinx version to be lower than 3.

Maybe we need a new release with this change.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
