### PR TITLE
remove django 1.10 example from tutorial

### DIFF
--- a/docs/tutorial/tutorial_01.rst
+++ b/docs/tutorial/tutorial_01.rst
@@ -51,13 +51,6 @@ CorsMiddleware should be placed as high as possible, especially before any middl
         # ...
     )
 
-    # Or on Django < 1.10:
-    MIDDLEWARE_CLASSES = (
-        # ...
-        'corsheaders.middleware.CorsMiddleware',
-        # ...
-    )
-
 Allow CORS requests from all domains (just for the scope of this tutorial):
 
 .. code-block:: python

--- a/docs/tutorial/tutorial_03.rst
+++ b/docs/tutorial/tutorial_03.rst
@@ -31,14 +31,6 @@ which takes care of token verification. In your settings.py:
         '...',
     )
 
-    # Or on Django<1.10:
-    MIDDLEWARE_CLASSES = (
-        '...',
-        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-        'oauth2_provider.middleware.OAuth2TokenMiddleware',
-        '...',
-    )
-
 You will likely use the `django.contrib.auth.backends.ModelBackend` along with the OAuth2 backend
 (or you might not be able to log in into the admin), only pay attention to the order in which
 Django processes authentication backends.


### PR DESCRIPTION
## Description of the Change

Remove Django 1.x code example from tutorial, because oauth2_provider only supports Django 2.x and 3.x.

## Checklist

- [x ] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
