### PR TITLE
split authorization code creation into OAuth2Validator._create_authorization_code 

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -446,9 +446,7 @@ class OAuth2Validator(RequestValidator):
         return grant.code_challenge_method or None
 
     def save_authorization_code(self, client_id, code, request, *args, **kwargs):
-        expires = timezone.now() + timedelta(
-            seconds=oauth2_settings.AUTHORIZATION_CODE_EXPIRE_SECONDS)
-        self._create_authorization_code(request, code, expires)
+        self._create_authorization_code(request, code)
 
     def rotate_refresh_token(self, request):
         """
@@ -563,7 +561,10 @@ class OAuth2Validator(RequestValidator):
             source_refresh_token=source_refresh_token,
         )
 
-    def _create_authorization_code(self, request, code, expires):
+    def _create_authorization_code(self, request, code, expires=None):
+        if not expires:
+            expires = timezone.now() + timedelta(seconds=oauth2_settings.AUTHORIZATION_CODE_EXPIRE_SECONDS)
+
         return Grant.objects.create(
             application=request.client,
             user=request.user,

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -448,16 +448,7 @@ class OAuth2Validator(RequestValidator):
     def save_authorization_code(self, client_id, code, request, *args, **kwargs):
         expires = timezone.now() + timedelta(
             seconds=oauth2_settings.AUTHORIZATION_CODE_EXPIRE_SECONDS)
-        Grant.objects.create(
-            application=request.client,
-            user=request.user,
-            code=code["code"],
-            expires=expires,
-            redirect_uri=request.redirect_uri,
-            scope=" ".join(request.scopes),
-            code_challenge=request.code_challenge or "",
-            code_challenge_method=request.code_challenge_method or ""
-        )
+        self._create_authorization_code(request, code, expires)
 
     def rotate_refresh_token(self, request):
         """
@@ -570,6 +561,18 @@ class OAuth2Validator(RequestValidator):
             token=token["access_token"],
             application=request.client,
             source_refresh_token=source_refresh_token,
+        )
+
+    def _create_authorization_code(self, request, code, expires):
+        return Grant.objects.create(
+            application=request.client,
+            user=request.user,
+            code=code["code"],
+            expires=expires,
+            redirect_uri=request.redirect_uri,
+            scope=" ".join(request.scopes),
+            code_challenge=request.code_challenge or "",
+            code_challenge_method=request.code_challenge_method or ""
         )
 
     def _create_refresh_token(self, request, refresh_token_code, access_token):


### PR DESCRIPTION
## Description of the Change

I'm subclassing OAuth2Validator to customize authorization code generation, and splitting authorization code creation into _create_authorization_code like _create_access_token, _create_refresh_token would make it easy. Otherwise, I would copy paste same code from save_authorization_code to customize it.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
