### PR TITLE
Change install documentation to include missing imports

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -19,11 +19,22 @@ If you need an OAuth2 provider you'll want to add the following to your urls.py
 
 .. code-block:: python
 
+    from django.urls import include, path
+
     urlpatterns = [
         ...
         path('o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+    ]
 
-        # using re_path
+Or using `re_path()`
+
+.. code-block:: python
+
+    from django.urls import include, re_path
+
+    urlpatterns = [
+        ...
+
         re_path(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     ]
 


### PR DESCRIPTION
Changes install documentation to include missing imports and split `path()` vs re_path()` solutions. 