### PR TITLE
Fix #847 Log an exception when response status is not OK

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,3 +29,4 @@ pySilver
 Rodney Richardson
 Silvano Cerza
 Stéphane Raimbault
+Jun Zhou

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### added
 * added `select_related` in intospect view for better query performance
 
+### Fixed
+* #847: Fix inappropriate message when response from authentication server is not OK.
 
 ## [1.3.2] 2020-03-24
 

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -1,5 +1,6 @@
 import base64
 import binascii
+import http.client
 import logging
 from collections import OrderedDict
 from datetime import datetime, timedelta
@@ -302,6 +303,14 @@ class OAuth2Validator(RequestValidator):
             )
         except requests.exceptions.RequestException:
             log.exception("Introspection: Failed POST to %r in token lookup", introspection_url)
+            return None
+
+        # Log an exception when response from auth server is not successful
+        if response.status_code != http.client.OK:
+            log.exception("Introspection: Failed to get a valid response "
+                          "from authentication server. status code ={}, "
+                          "reason {}".format(response.status_code,
+                                             response.reason))
             return None
 
         try:

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -308,9 +308,9 @@ class OAuth2Validator(RequestValidator):
         # Log an exception when response from auth server is not successful
         if response.status_code != http.client.OK:
             log.exception("Introspection: Failed to get a valid response "
-                          "from authentication server. status code ={}, "
-                          "reason {}".format(response.status_code,
-                                             response.reason))
+                          "from authentication server. Status code: {}, "
+                          "Reason: {}.".format(response.status_code,
+                                               response.reason))
             return None
 
         try:

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -2,7 +2,7 @@ import contextlib
 import datetime
 
 from django.contrib.auth import get_user_model
-from django.test import TransactionTestCase
+from django.test import TransactionTestCase, TestCase
 from django.utils import timezone
 from oauthlib.common import Request
 
@@ -392,3 +392,26 @@ class TestOAuth2ValidatorProvidesErrorData(TransactionTestCase):
         self.assertDictEqual(self.request.oauth2_error, {
             "error": "invalid_token",
         })
+
+
+class TestOAuth2ValidatorErrorResourceToken(TestCase):
+    """The following tests check logger information when response from oauth2
+    is unsuccessful.
+    """
+
+    def setUp(self):
+        self.token = 'test_token'
+        self.introspection_url = 'http://example.com/token/introspection/'
+        self.introspection_token = 'test_introspection_token'
+        self.validator = OAuth2Validator()
+
+    def test_response_when_auth_server_response_return_404(self):
+        with self.assertLogs(logger='oauth2_provider') as mock_log:
+            self.validator._get_token_from_authentication_server(
+                self.token, self.introspection_url,
+                self.introspection_token, None)
+            self.assertIn("ERROR:oauth2_provider:Introspection: Failed to "
+                          "get a valid response from authentication server. "
+                          "Status code: 404, Reason: "
+                          "Not Found.\nNoneType: None",
+                          mock_log.output)

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -400,13 +400,13 @@ class TestOAuth2ValidatorErrorResourceToken(TestCase):
     """
 
     def setUp(self):
-        self.token = 'test_token'
-        self.introspection_url = 'http://example.com/token/introspection/'
-        self.introspection_token = 'test_introspection_token'
+        self.token = "test_token"
+        self.introspection_url = "http://example.com/token/introspection/"
+        self.introspection_token = "test_introspection_token"
         self.validator = OAuth2Validator()
 
     def test_response_when_auth_server_response_return_404(self):
-        with self.assertLogs(logger='oauth2_provider') as mock_log:
+        with self.assertLogs(logger="oauth2_provider") as mock_log:
             self.validator._get_token_from_authentication_server(
                 self.token, self.introspection_url,
                 self.introspection_token, None)

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -2,7 +2,7 @@ import contextlib
 import datetime
 
 from django.contrib.auth import get_user_model
-from django.test import TransactionTestCase, TestCase
+from django.test import TestCase, TransactionTestCase
 from django.utils import timezone
 from oauthlib.common import Request
 


### PR DESCRIPTION
By providing the status code and its reason to logger, the error message would be more explicit for debugger whenever there is an issue related to resource token or other errors.

<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #847 

## Description of the Change
Added a checker to log an exception when the response from authentication server is not successful. With such change, the real issue with the response would not be changed to a JSONDecoderError which would be a distraction for debugging.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
