### PR TITLE
Passing None into middleware is deprecated

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,3 +30,4 @@ Rodney Richardson
 Silvano Cerza
 Stéphane Raimbault
 Jun Zhou
+David Smith

--- a/tests/test_auth_backends.py
+++ b/tests/test_auth_backends.py
@@ -88,8 +88,11 @@ class TestOAuth2Middleware(BaseTest):
         super(TestOAuth2Middleware, self).setUp()
         self.anon_user = AnonymousUser()
 
+    def dummy_get_response(request):
+        return None
+
     def test_middleware_wrong_headers(self):
-        m = OAuth2TokenMiddleware()
+        m = OAuth2TokenMiddleware(self.dummy_get_response)
         request = self.factory.get("/a-resource")
         self.assertIsNone(m.process_request(request))
         auth_headers = {
@@ -99,7 +102,7 @@ class TestOAuth2Middleware(BaseTest):
         self.assertIsNone(m.process_request(request))
 
     def test_middleware_user_is_set(self):
-        m = OAuth2TokenMiddleware()
+        m = OAuth2TokenMiddleware(self.dummy_get_response)
         auth_headers = {
             "HTTP_AUTHORIZATION": "Bearer " + "tokstr",
         }
@@ -110,7 +113,7 @@ class TestOAuth2Middleware(BaseTest):
         self.assertIsNone(m.process_request(request))
 
     def test_middleware_success(self):
-        m = OAuth2TokenMiddleware()
+        m = OAuth2TokenMiddleware(self.dummy_get_response)
         auth_headers = {
             "HTTP_AUTHORIZATION": "Bearer " + "tokstr",
         }
@@ -119,7 +122,7 @@ class TestOAuth2Middleware(BaseTest):
         self.assertEqual(request.user, self.user)
 
     def test_middleware_response(self):
-        m = OAuth2TokenMiddleware()
+        m = OAuth2TokenMiddleware(self.dummy_get_response)
         auth_headers = {
             "HTTP_AUTHORIZATION": "Bearer " + "tokstr",
         }
@@ -129,7 +132,7 @@ class TestOAuth2Middleware(BaseTest):
         self.assertIs(response, processed)
 
     def test_middleware_response_header(self):
-        m = OAuth2TokenMiddleware()
+        m = OAuth2TokenMiddleware(self.dummy_get_response)
         auth_headers = {
             "HTTP_AUTHORIZATION": "Bearer " + "tokstr",
         }


### PR DESCRIPTION
# Fixes 
passing get_response into middleware is deprecated in Django 3.1. This pull request creates a fake request object to pass into the middleware. 

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
