### PR TITLE
Removed inheritance from `object`

### DIFF
--- a/oauth2_provider/backends.py
+++ b/oauth2_provider/backends.py
@@ -7,7 +7,7 @@ UserModel = get_user_model()
 OAuthLibCore = get_oauthlib_core()
 
 
-class OAuth2Backend(object):
+class OAuth2Backend:
     """
     Authenticate against an OAuth2 access token
     """

--- a/oauth2_provider/generators.py
+++ b/oauth2_provider/generators.py
@@ -4,7 +4,7 @@ from oauthlib.common import generate_client_id as oauthlib_generate_client_id
 from .settings import oauth2_settings
 
 
-class BaseHashGenerator(object):
+class BaseHashGenerator:
     """
     All generators should extend this class overriding `.hash()` method.
     """

--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -9,7 +9,7 @@ from .exceptions import FatalClientError, OAuthToolkitError
 from .settings import oauth2_settings
 
 
-class OAuthLibCore(object):
+class OAuthLibCore:
     """
     Wrapper for oauth Server providing django-specific interfaces.
 

--- a/oauth2_provider/scopes.py
+++ b/oauth2_provider/scopes.py
@@ -1,7 +1,7 @@
 from .settings import oauth2_settings
 
 
-class BaseScopes(object):
+class BaseScopes:
     def get_all_scopes(self):
         """
         Return a dict-like object with all the scopes available in the

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -157,7 +157,7 @@ def import_from_string(val, setting_name):
         raise ImportError(msg)
 
 
-class OAuth2ProviderSettings(object):
+class OAuth2ProviderSettings:
     """
     A settings object, that allows OAuth2 Provider settings to be accessed as properties.
 

--- a/oauth2_provider/views/mixins.py
+++ b/oauth2_provider/views/mixins.py
@@ -13,7 +13,7 @@ log = logging.getLogger("oauth2_provider")
 SAFE_HTTP_METHODS = ["GET", "HEAD", "OPTIONS"]
 
 
-class OAuthLibMixin(object):
+class OAuthLibMixin:
     """
     This mixin decouples Django OAuth Toolkit from OAuthLib.
 
@@ -195,7 +195,7 @@ class OAuthLibMixin(object):
         return core.authenticate_client(request)
 
 
-class ScopedResourceMixin(object):
+class ScopedResourceMixin:
     """
     Helper mixin that implements "scopes handling" behaviour
     """

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -58,7 +58,7 @@ class TestOAuthLibMixin(BaseTest):
         self.assertIsInstance(test_view.get_server(), Server)
 
     def test_custom_backend(self):
-        class AnotherOauthLibBackend(object):
+        class AnotherOauthLibBackend:
             pass
 
         class TestView(OAuthLibMixin, View):


### PR DESCRIPTION
A small tidy up -- `object` is no longer required.