### PR TITLE
Passing `providing_args` into `Signal` is deprecated

### DIFF
--- a/oauth2_provider/signals.py
+++ b/oauth2_provider/signals.py
@@ -1,4 +1,4 @@
 from django.dispatch import Signal
 
 
-app_authorized = Signal(providing_args=["request", "token"])
+app_authorized = Signal()  # providing_args=["request", "token"]


### PR DESCRIPTION
For documentation only -- left in code as a comment

```
 RemovedInDjango40Warning: The providing_args argument is deprecated.
 As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docst
ring.
    app_authorized = Signal(providing_args=["request", "token"])
```
