### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,46 @@ matrix:
     - python: 3.6
       env: TOXENV=py36-django21
 
-    - python: 3.5
-      env: TOXENV=py35-django22
-    - python: 3.5
-      env: TOXENV=py35-django21
+      # Adding jobs for ppc64le
+    - python: 3.7
+      arch: ppc64le
+      env: TOXENV=py37-flake8
+    - python: 3.7
+      arch: ppc64le
+      env: TOXENV=py37-docs
+
+    - python: 3.8
+      arch: ppc64le
+      env: TOXENV=py38-django30
+    - python: 3.8
+      arch: ppc64le
+      env: TOXENV=py38-django22
+    - python: 3.8
+      arch: ppc64le
+      env: TOXENV=py38-django21
+    - python: 3.8
+      arch: ppc64le
+      env: TOXENV=py38-djangomaster
+
+    - python: 3.7
+      arch: ppc64le
+      env: TOXENV=py37-django30
+    - python: 3.7
+      arch: ppc64le
+      env: TOXENV=py37-django22
+    - python: 3.7
+      arch: ppc64le
+      env: TOXENV=py37-django21
+    - python: 3.7
+      arch: ppc64le
+      env: TOXENV=py37-djangomaster
+
+    - python: 3.6
+      arch: ppc64le
+      env: TOXENV=py36-django22
+    - python: 3.6
+      arch: ppc64le
+      env: TOXENV=py36-django21
 
 install:
   - pip install coveralls tox tox-travis


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/django-oauth-toolkit/jobs/397298274

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj