### PR TITLE
Updated url() to path()

### DIFF
--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,13 +1,13 @@
-from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import include, path
 
 
 admin.autodiscover()
 
 
 urlpatterns = [
-    url(r"^o/", include("oauth2_provider.urls", namespace="oauth2_provider")),
+    path("o/", include("oauth2_provider.urls", namespace="oauth2_provider")),
 ]
 
 
-urlpatterns += [url(r"^admin/", admin.site.urls)]
+urlpatterns += [path("admin/", admin.site.urls)]


### PR DESCRIPTION
## Changed URL patterns to use path() instead of url()

URL() is deprecated in Django 3.1 and path() is available in all supported versions of Django.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
