### PR TITLE
Added Python 3.9 to test matrix for djangomaster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ matrix:
 
     - python: 3.9
       env: TOXENV=py39-djangomaster
+    - python: 3.9
+      env: TOXENV=py39-django30
+    - python: 3.9
+      env: TOXENV=py39-django22
 
     - python: 3.8
       env: TOXENV=py38-django30

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-docs
 
-    - python: 3.9-dev
+    - python: 3.9
       env: TOXENV=py39-djangomaster
-    - python: 3.9-dev
+    - python: 3.9
       env: TOXENV=py39-django30
-    - python: 3.9-dev
+    - python: 3.9
       env: TOXENV=py39-django22
 
     - python: 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-docs
 
-    - python: 3.9
+    - python: 3.9-dev
       env: TOXENV=py39-djangomaster
-    - python: 3.9
+    - python: 3.9-dev
       env: TOXENV=py39-django30
-    - python: 3.9
+    - python: 3.9-dev
       env: TOXENV=py39-django22
 
     - python: 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,16 @@ matrix:
     - env: TOXENV=py36-djangomaster
     - env: TOXENV=py37-djangomaster      
     - env: TOXENV=py38-djangomaster
+    - env: TOXENV=py39-djangomaster
 
   include:
     - python: 3.7
       env: TOXENV=py37-flake8
     - python: 3.7
       env: TOXENV=py37-docs
+
+    - python: 3.9
+      env: TOXENV=py39-djangomaster
 
     - python: 3.8
       env: TOXENV=py38-django30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+* #884 Added support for Python 3.9
+
 ## [1.3.3] 2020-10-16
 
 ### Added

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
 	Programming Language :: Python :: 3.6
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
+	Programming Language :: Python :: 3.9
 	Topic :: Internet :: WWW/HTTP
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
 	py37-django{30,22,21},
 	py36-django{22,21},
 	py35-django{22,21},
+	py39-djangomaster,
 	py38-djangomaster,
 	py37-djangomaster,
 	py36-djangomaster,

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
 	py37-django{30,22,21},
 	py36-django{22,21},
 	py35-django{22,21},
+	py39-django{22,30}
 	py39-djangomaster,
 	py38-djangomaster,
 	py37-djangomaster,


### PR DESCRIPTION
# Description of the Change

Adds Python 3.9 to test matrix. Currently, released versions of Django don't officially support Python 3.9 but let's test against the 'master' branch for now. 

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
