### PR TITLE
pass PKCE fields to AuthorizationView form

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,3 +31,4 @@ Silvano Cerza
 Stéphane Raimbault
 Jun Zhou
 David Smith
+Łukasz Skarżyński

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -156,6 +156,10 @@ class AuthorizationView(BaseAuthorizationView, FormView):
         kwargs["redirect_uri"] = credentials["redirect_uri"]
         kwargs["response_type"] = credentials["response_type"]
         kwargs["state"] = credentials["state"]
+        if "code_challenge" in credentials:
+            kwargs["code_challenge"] = credentials["code_challenge"]
+        if "code_challenge_method" in credentials:
+            kwargs["code_challenge_method"] = credentials["code_challenge_method"]
 
         self.oauth2_data = kwargs
         # following two loc are here only because of https://code.djangoproject.com/ticket/17795

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -1012,7 +1012,7 @@ class TestAuthorizationCodeTokenView(BaseTest):
         """
         Request an access token using client_type: public
         and PKCE enabled. Tests if the authorize get is successfull
-        for the S256 algorithm
+        for the S256 algorithm and form data are properly passed.
         """
         self.client.login(username="test_user", password="123456")
 
@@ -1033,14 +1033,15 @@ class TestAuthorizationCodeTokenView(BaseTest):
         }
 
         response = self.client.get(reverse("oauth2_provider:authorize"), data=query_data)
-        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'value="S256"', count=1, status_code=200)
+        self.assertContains(response, 'value="{0}"'.format(code_challenge), count=1, status_code=200)
         oauth2_settings.PKCE_REQUIRED = False
 
     def test_public_pkce_plain_authorize_get(self):
         """
         Request an access token using client_type: public
         and PKCE enabled. Tests if the authorize get is successfull
-        for the plain algorithm
+        for the plain algorithm and form data are properly passed.
         """
         self.client.login(username="test_user", password="123456")
 
@@ -1061,7 +1062,8 @@ class TestAuthorizationCodeTokenView(BaseTest):
         }
 
         response = self.client.get(reverse("oauth2_provider:authorize"), data=query_data)
-        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'value="plain"', count=1, status_code=200)
+        self.assertContains(response, 'value="{0}"'.format(code_challenge), count=1, status_code=200)
         oauth2_settings.PKCE_REQUIRED = False
 
     def test_public_pkce_S256(self):


### PR DESCRIPTION
Hi :wave: 

first of all thanks for developing and maintaining a great project!

<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
<!-- Fixes # -->

## Description of the Change

Pass `code_challenge` and `code_challenge_method` from query string to `AuthorizationView` form in `get()`.
Without this, it was impossible to use authorization code grant flow with `GET`, because `code_challenge` and `code_challenge_method` data were never passed to form, so they weren't in `form.cleaned_data`, which causes creating `Grant` with always empty `code_challenge` and `code_challenge_method`.

This issue was quite hard bug to discover because there are already few tests for authorization code flow pkce, however, they weren't checking form rendering in `GET` request, but only `response.status_code`, I have added asserts for these 2 values, please look at the changes in `test_public_pkce_plain_authorize_get` and `test_public_pkce_S256_authorize_get` tests in `test_authorization_code.py`.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
