### PR TITLE
Update docs to about default ACCESS_TOKEN_EXPIRE_SECONDS

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -31,7 +31,7 @@ ACCESS_TOKEN_EXPIRE_SECONDS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The number of seconds an access token remains valid. Requesting a protected
 resource after this duration will fail. Keep this value high enough so clients
-can cache the token for a reasonable amount of time.
+can cache the token for a reasonable amount of time. (default: 36000)
 
 ACCESS_TOKEN_MODEL
 ~~~~~~~~~~~~~~~~~~
@@ -142,7 +142,7 @@ The number of seconds before a refresh token gets removed from the database by
 the ``cleartokens`` management command. Check :ref:`cleartokens` management command for further info.
 NOTE: This value is completely ignored when validating refresh tokens.
 If you don't change the validator code and don't run cleartokens all refresh
-tokens will last until revoked or the end of time.
+tokens will last until revoked or the end of time. You should change this.
 
 REFRESH_TOKEN_GRACE_PERIOD_SECONDS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description of the Change
This PR adds to the documentation details of the access token expires and a stronger suggestion to expire refresh tokens.

## Checklist
- [x] PR only contains one change (considered splitting up PR)
- [x] documentation updated
