### PR TITLE
remove MiddlewareMixin use

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,3 +39,4 @@ David Smith
 Tom Evans
 Dylan Giesler
 Spencer Carroll
+Dulmandakh Sukhbaatar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [1.4.1]
+
+### Changed
+* #925 OAuth2TokenMiddleware converted to new style middleware, and no longer extends MiddlewareMixin.
+
 ## [1.4.0] 2021-02-08
 
 ### Added

--- a/oauth2_provider/middleware.py
+++ b/oauth2_provider/middleware.py
@@ -1,9 +1,8 @@
 from django.contrib.auth import authenticate
 from django.utils.cache import patch_vary_headers
-from django.utils.deprecation import MiddlewareMixin
 
 
-class OAuth2TokenMiddleware(MiddlewareMixin):
+class OAuth2TokenMiddleware:
     """
     Middleware for OAuth2 user authentication
 
@@ -22,8 +21,10 @@ class OAuth2TokenMiddleware(MiddlewareMixin):
     It also adds "Authorization" to the "Vary" header, so that django's cache middleware or a
     reverse proxy can create proper cache keys.
     """
+    def __init__(self, get_response):
+        self.get_response = get_response
 
-    def process_request(self, request):
+    def __call__(self, request):
         # do something only if request contains a Bearer token
         if request.META.get("HTTP_AUTHORIZATION", "").startswith("Bearer"):
             if not hasattr(request, "user") or request.user.is_anonymous:
@@ -31,6 +32,6 @@ class OAuth2TokenMiddleware(MiddlewareMixin):
                 if user:
                     request.user = request._cached_user = user
 
-    def process_response(self, request, response):
+        response = self.get_response(request)
         patch_vary_headers(response, ("Authorization",))
         return response

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     docs,
     py{36,37,38,39}-dj{31,30,22},
     py35-dj{22},
-    py{36,37,38,39}-djmaster,
+    py{38,39}-djmaster,
 
 [gh-actions]
 python =
@@ -42,7 +42,7 @@ deps =
 passenv =
 	PYTEST_ADDOPTS
 
-[testenv:py{36,37,38,39}-djmaster]
+[testenv:py{38,39}-djmaster]
 ignore_errors = true
 ignore_outcome = true
 


### PR DESCRIPTION
## Description of the Change

Remove MiddlewareMixin use, and convert to new style Django middleware.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
