### PR TITLE
Fix wrong import

### DIFF
--- a/docs/tutorial/tutorial_02.rst
+++ b/docs/tutorial/tutorial_02.rst
@@ -34,7 +34,7 @@ URL this view will respond to:
 
 .. code-block:: python
 
-    from django.conf.urls import path, include
+    from django.urls import path, include
     import oauth2_provider.views as oauth2_views
     from django.conf import settings
     from .views import ApiEndpoint

--- a/docs/tutorial/tutorial_02.rst
+++ b/docs/tutorial/tutorial_02.rst
@@ -34,7 +34,7 @@ URL this view will respond to:
 
 .. code-block:: python
 
-    from django.conf.urls import url, include
+    from django.conf.urls import path, include
     import oauth2_provider.views as oauth2_views
     from django.conf import settings
     from .views import ApiEndpoint


### PR DESCRIPTION
Fix wrong import from `url` (unused in example) to `path`.

Fixes #

Just a quick fix.
