### PR TITLE
Django renamed the master branch to main

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     docs,
     py{36,37,38,39}-dj{31,30,22},
     py35-dj{22},
-    py{38,39}-djmaster,
+    py{38,39}-djmain,
 
 [gh-actions]
 python =
@@ -30,7 +30,7 @@ deps =
     dj22: Django>=2.2,<3
     dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
-    djmaster: https://github.com/django/django/archive/master.tar.gz
+    djmain: https://github.com/django/django/archive/main.tar.gz
     djangorestframework
     oauthlib>=3.1.0
     coverage
@@ -42,7 +42,7 @@ deps =
 passenv =
 	PYTEST_ADDOPTS
 
-[testenv:py{38,39}-djmaster]
+[testenv:py{38,39}-djmain]
 ignore_errors = true
 ignore_outcome = true
 


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->

## Description of the Change

Fixes failed djmaster tox tests since upstream django renamed the `master` branch to `main`.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
