### PR TITLE
Fix weird grammar in messages on authorize screen

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ Tom Evans
 Dylan Giesler
 Spencer Carroll
 Dulmandakh Sukhbaatar
+Will Beaufoy

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -1,5 +1,5 @@
-`Models`
-========
+Models
+======
 
 .. automodule:: oauth2_provider.models
     :members:

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -100,7 +100,7 @@ Example (this is the default page you may find on ``templates/oauth2_provider/au
                         {% endif %}
                     {% endfor %}
 
-                    <p>{% trans "Application requires following permissions" %}</p>
+                    <p>{% trans "Application requires the following permissions" %}</p>
                     <ul>
                         {% for scope in scopes_descriptions %}
                             <li>{{ scope }}</li>

--- a/oauth2_provider/locale/pt/LC_MESSAGES/django.po
+++ b/oauth2_provider/locale/pt/LC_MESSAGES/django.po
@@ -21,7 +21,7 @@ msgstr "Autorizar"
 
 #: docs/_build/html/_sources/templates.rst.txt:103
 #: oauth2_provider/templates/oauth2_provider/authorize.html:17
-msgid "Application requires following permissions"
+msgid "Application requires the following permissions"
 msgstr "A aplicação requer as seguintes permissões"
 
 #: oauth2_provider/models.py:41

--- a/oauth2_provider/templates/oauth2_provider/authorize.html
+++ b/oauth2_provider/templates/oauth2_provider/authorize.html
@@ -14,7 +14,7 @@
                     {% endif %}
                 {% endfor %}
 
-                <p>{% trans "Application requires following permissions" %}</p>
+                <p>{% trans "Application requires the following permissions" %}</p>
                 <ul>
                     {% for scope in scopes_descriptions %}
                         <li>{{ scope }}</li>


### PR DESCRIPTION
## Description of the Change

The existing message to users was 'Application requires following permissions' which sounds
like bad english to me. I've changed them to 'Application requires the following permissions'.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
