### PR TITLE
Drop retired Python 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.5' ,'3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/AUTHORS
+++ b/AUTHORS
@@ -41,3 +41,4 @@ Dylan Giesler
 Spencer Carroll
 Dulmandakh Sukhbaatar
 Will Beaufoy
+Rustem Saiargaliev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Removed
+* Remove support for Python 3.5
+
 ## [1.4.1]
 
 ### Changed

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Please report any security issues to the JazzBand security team at <security@jaz
 Requirements
 ------------
 
-* Python 3.5+
+* Python 3.6+
 * Django 2.1+
 * oauthlib 3.1+
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ If you need support please send a message to the `Django OAuth Toolkit Google Gr
 Requirements
 ------------
 
-* Python 3.5+
+* Python 3.6+
 * Django 2.2+
 * oauthlib 3.1+
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 110
-target-version = ['py35']
+target-version = ['py38']
 exclude = '''
 ^/(
         oauth2_provider/migrations/

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
 	License :: OSI Approved :: BSD License
 	Operating System :: OS Independent
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.5
 	Programming Language :: Python :: 3.6
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,10 @@ envlist =
     flake8,
     docs,
     py{36,37,38,39}-dj{31,30,22},
-    py35-dj{22},
     py{38,39}-djmain,
 
 [gh-actions]
 python =
-    3.5: py35
     3.6: py36
     3.7: py37
     3.8: py38, docs, flake8


### PR DESCRIPTION
## Description of the Change

Python 3.5 did reach end-of-life in September 2020:
https://www.python.org/downloads/release/python-3510/

We can safely remove it from CI to reduce test running time.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
