### PR TITLE
GitHub Actions: smart run strategy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
 
 jobs:
   build:

--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ Tom Evans
 Dylan Giesler
 Spencer Carroll
 Dulmandakh Sukhbaatar
+Rustem Saiargaliev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+* GitHub Actions: run CI on PRs and pushes to master only
+
 ## [1.4.1]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-### Fixed
-* GitHub Actions: run CI on PRs and pushes to master only
-
 ## [1.4.1]
 
 ### Changed


### PR DESCRIPTION
## Description of the Change

Previously, every pull request was running actions twice, since two signals were fired - push commit in the PR and new PR itself.

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#webhook-events

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
