### PR TITLE
Fix #524 - Restrict usage of timezone aware expire dates to Django projects with USE_TZ set to True

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,3 +43,4 @@ Spencer Carroll
 Dulmandakh Sukhbaatar
 Will Beaufoy
 Rustem Saiargaliev
+Jadiel Teófilo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * #915 Add optional OpenID Connect support.
+### Fixed
+* #524 Restrict usage of timezone aware expire dates to Django projects with USE_TZ set to True.
 
 ## [1.4.1]
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -310,3 +310,12 @@ OIDC_TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED
 Default: ``["client_secret_post", "client_secret_basic"]``
 
 The authentication methods that are advertised to be supported by this server.
+
+
+Settings imported from Django project
+--------------------------
+
+USE_TZ
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Used to determine whether or not to make token expire dates timezone aware.

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -357,7 +357,7 @@ class OAuth2Validator(RequestValidator):
                 expires = max_caching_time
 
             scope = content.get("scope", "")
-            expires = make_aware(expires)
+            expires = make_aware(expires) if settings.USE_TZ else expires
 
             access_token, _created = AccessToken.objects.update_or_create(
                 token=token,

--- a/tests/test_introspection_auth.py
+++ b/tests/test_introspection_auth.py
@@ -13,6 +13,7 @@ from oauthlib.common import Request
 
 from oauth2_provider.models import get_access_token_model, get_application_model
 from oauth2_provider.oauth2_validators import OAuth2Validator
+from oauth2_provider.settings import oauth2_settings
 from oauth2_provider.views import ScopedProtectedResourceView
 
 from . import presets

--- a/tests/test_introspection_auth.py
+++ b/tests/test_introspection_auth.py
@@ -2,6 +2,7 @@ import calendar
 import datetime
 
 import pytest
+from django.conf import settings
 from django.conf.urls import include
 from django.contrib.auth import get_user_model
 from django.http import HttpResponse
@@ -153,6 +154,25 @@ class TestTokenIntrospectionAuth(TestCase):
         self.assertIsInstance(token, AccessToken)
         self.assertEqual(token.user.username, "foo_user")
         self.assertEqual(token.scope, "read write dolphin")
+
+    @mock.patch("requests.post", side_effect=mocked_requests_post)
+    def test_get_token_from_authentication_server_expires_timezone(self, mock_get):
+        """
+        Test method _get_token_from_authentication_server for projects with USE_TZ False
+        """
+        settings_use_tz_backup = settings.USE_TZ
+        settings.USE_TZ = False
+        try:
+            self.validator._get_token_from_authentication_server(
+                "foo",
+                oauth2_settings.RESOURCE_SERVER_INTROSPECTION_URL,
+                oauth2_settings.RESOURCE_SERVER_AUTH_TOKEN,
+                oauth2_settings.RESOURCE_SERVER_INTROSPECTION_CREDENTIALS,
+            )
+        except ValueError as exception:
+            self.fail(str(exception))
+        finally:
+            settings.USE_TZ = settings_use_tz_backup
 
     @mock.patch("requests.post", side_effect=mocked_requests_post)
     def test_validate_bearer_token(self, mock_get):


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #

## Description of the Change

Fixes #524. Restrict usage of timezone aware expire dates to Django projects with USE_TZ set to True.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
