### PR TITLE
Provide django.contrib.auth.authenticate() with a request for compatibiity with more backends. 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,3 +50,4 @@ Rustem Saiargaliev
 Jadiel Teófilo
 pySilver
 Łukasz Skarżyński
+Shaheed Haque

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   -->
 
 ## [unreleased]
+
+### Added
 * #712, #636, #808. Calls to `django.contrib.auth.authenticate()` now pass a `request`
   to provide compatibility with backends that need one.
+  
+### Fixed
+* #524 Restrict usage of timezone aware expire dates to Django projects with USE_TZ set to True.
 
 ## [1.5.0] 2021-03-18
 
 ### Added
 * #915 Add optional OpenID Connect support.
-### Fixed
-* #524 Restrict usage of timezone aware expire dates to Django projects with USE_TZ set to True.
 
 ### Changed
 * #942 Help via defunct Google group replaced with using GitHub issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
   -->
 
+## [unreleased]
+* #712, #636, #808. Calls to `django.contrib.auth.authenticate()` now pass a `request`
+  to provide compatibility with backends that need one.
+
 ## [1.5.0] 2021-03-18
 
 ### Added

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -14,6 +14,7 @@ from django.contrib.auth import authenticate, get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.models import Q
+from django.http import HttpRequest
 from django.utils import dateformat, timezone
 from django.utils.timezone import make_aware
 from django.utils.translation import gettext_lazy as _
@@ -664,7 +665,18 @@ class OAuth2Validator(RequestValidator):
         """
         Check username and password correspond to a valid and active User
         """
-        u = authenticate(username=username, password=password)
+        # Passing the optional HttpRequest adds compatibility for backends
+        # which depend on its presence. Create one with attributes likely
+        # to be used.
+        http_request = HttpRequest()
+        http_request.path = request.uri
+        http_request.method = request.http_method
+        if request.http_method == "GET":
+            http_request.GET.update(dict(request.decoded_body))
+        elif request.http_method == "POST":
+            http_request.POST.update(dict(request.decoded_body))
+        http_request.META = request.headers
+        u = authenticate(http_request, username=username, password=password)
         if u is not None and u.is_active:
             request.user = u
             return True

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -671,10 +671,7 @@ class OAuth2Validator(RequestValidator):
         http_request = HttpRequest()
         http_request.path = request.uri
         http_request.method = request.http_method
-        if request.http_method == "GET":
-            http_request.GET.update(dict(request.decoded_body))
-        elif request.http_method == "POST":
-            http_request.POST.update(dict(request.decoded_body))
+        getattr(http_request, request.http_method).update(dict(request.decoded_body))
         http_request.META = request.headers
         u = authenticate(http_request, username=username, password=password)
         if u is not None and u.is_active:


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #712
Fixes #636
Fixes #808

## Description of the Change

The function django.contrib.auth.authenticate() has an optional first `request` argument. Some backends, such as django-axes (i.e. the subject of #712) and others (i.e. the subject of #636) *require* this argument to be present. This change provides this argument.

Additionally, this change is based on the patch in #712, and constructs a Django HttpRequest object from the DOT request object in order to provide API compatibility. This avoid the issue that caused the original fix for #636 to be reverted, and also addresses #808.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
