### PR TITLE
Allow loopback redirect URIs using ports as described in RFC8252

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Jim Graham
 Jonathan Steffan
 Jun Zhou
 Kristian Rune Larsen
+Paul Dekkers
 Paul Oswald
 Pavel Tvrdík
 Rodney Richardson

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * #524 Restrict usage of timezone aware expire dates to Django projects with USE_TZ set to True.
-* #953 Allow loopback redirect URIs with random ports using http scheme, localhost address and no pinned port for Oauth2 Applications (RFC8252)
+* #953 Allow loopback redirect URIs with random ports using http scheme, localhost address and no explicit port
+  configuration in the allowed redirect_uris for Oauth2 Applications (RFC8252)
 
 ## [1.5.0] 2021-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * #524 Restrict usage of timezone aware expire dates to Django projects with USE_TZ set to True.
-* #953 Allow loopback redirect URIs with ports using http scheme and localhost address for Oauth2 Applications
+* #953 Allow loopback redirect URIs with random ports using http scheme, localhost address and no pinned port for Oauth2 Applications (RFC8252)
 
 ## [1.5.0] 2021-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * #712, #636, #808. Calls to `django.contrib.auth.authenticate()` now pass a `request`
   to provide compatibility with backends that need one.
-  
+
 ### Fixed
 * #524 Restrict usage of timezone aware expire dates to Django projects with USE_TZ set to True.
+* #953 Allow loopback redirect URIs with ports using http scheme and localhost address for Oauth2 Applications
 
 ## [1.5.0] 2021-03-18
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -52,6 +52,10 @@ Default: ``["http", "https"]``
 A list of schemes that the ``redirect_uri`` field will be validated against.
 Setting this to ``["https"]`` only in production is strongly recommended.
 
+For Native Apps the ``http`` scheme can be used without port specification in the
+``redirect_uri`` field, so that the Application accepts randomly assigned ports.
+If a port is specified, it requires a match.
+
 Note that you may override ``Application.get_allowed_schemes()`` to set this on
 a per-application basis.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -52,9 +52,10 @@ Default: ``["http", "https"]``
 A list of schemes that the ``redirect_uri`` field will be validated against.
 Setting this to ``["https"]`` only in production is strongly recommended.
 
-For Native Apps the ``http`` scheme can be used without port specification in the
-``redirect_uri`` field, so that the Application accepts randomly assigned ports.
-If a port is specified, it requires a match.
+For Native Apps the ``http`` scheme can be safely used with loopback addresses in the
+Application (``[::1]`` or ``127.0.0.1``). In this case the ``redirect_uri`` can be
+configured without explicit port specification, so that the Application accepts randomly
+assigned ports.
 
 Note that you may override ``Application.get_allowed_schemes()`` to set this on
 a per-application basis.

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -131,6 +131,11 @@ class AbstractApplication(models.Model):
             parsed_allowed_uri = urlparse(allowed_uri)
 
             if (
+                parsed_allowed_uri.scheme == parsed_uri.scheme == "http"
+                and parsed_uri.hostname in ["127.0.0.1", "::1"]
+                and parsed_allowed_uri.hostname == parsed_uri.hostname
+                and parsed_allowed_uri.path == parsed_uri.path
+            ) or (
                 parsed_allowed_uri.scheme == parsed_uri.scheme
                 and parsed_allowed_uri.netloc == parsed_uri.netloc
                 and parsed_allowed_uri.path == parsed_uri.path

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -125,29 +125,7 @@ class AbstractApplication(models.Model):
 
         :param uri: Url to check
         """
-        parsed_uri = urlparse(uri)
-        uqs_set = set(parse_qsl(parsed_uri.query))
-        for allowed_uri in self.redirect_uris.split():
-            parsed_allowed_uri = urlparse(allowed_uri)
-
-            if (
-                parsed_allowed_uri.scheme == parsed_uri.scheme == "http"
-                and parsed_uri.hostname in ["127.0.0.1", "::1"]
-                and isinstance(parsed_allowed_uri.port, type(None))
-                and parsed_allowed_uri.hostname == parsed_uri.hostname
-                and parsed_allowed_uri.path == parsed_uri.path
-            ) or (
-                parsed_allowed_uri.scheme == parsed_uri.scheme
-                and parsed_allowed_uri.netloc == parsed_uri.netloc
-                and parsed_allowed_uri.path == parsed_uri.path
-            ):
-
-                aqs_set = set(parse_qsl(parsed_allowed_uri.query))
-
-                if aqs_set.issubset(uqs_set):
-                    return True
-
-        return False
+        return redirect_to_uri_allowed(uri, self.redirect_uris.split())
 
     def clean(self):
         from django.core.exceptions import ValidationError
@@ -680,3 +658,50 @@ def clear_expired():
 
         access_tokens.delete()
         grants.delete()
+
+
+def redirect_to_uri_allowed(uri, allowed_uris):
+    """
+    Checks if a given uri can be redirected to based on the provided allowed_uris configuration.
+
+    On top of exact matches, this function also handles loopback IPs based on RFC 8252.
+
+    :param uri: URI to check
+    :param allowed_uris: A list of URIs that are allowed
+    """
+
+    parsed_uri = urlparse(uri)
+    uqs_set = set(parse_qsl(parsed_uri.query))
+    for allowed_uri in allowed_uris:
+        parsed_allowed_uri = urlparse(allowed_uri)
+
+        # From RFC 8252 (Section 7.3)
+        #
+        # Loopback redirect URIs use the "http" scheme
+        # [...]
+        # The authorization server MUST allow any port to be specified at the
+        # time of the request for loopback IP redirect URIs, to accommodate
+        # clients that obtain an available ephemeral port from the operating
+        # system at the time of the request.
+
+        allowed_uri_is_loopback = (
+            parsed_allowed_uri.scheme == "http"
+            and parsed_allowed_uri.hostname in ["127.0.0.1", "::1"]
+            and parsed_allowed_uri.port is None
+        )
+        if (
+            allowed_uri_is_loopback
+            and parsed_allowed_uri.scheme == parsed_uri.scheme
+            and parsed_allowed_uri.hostname == parsed_uri.hostname
+            and parsed_allowed_uri.path == parsed_uri.path
+        ) or (
+            parsed_allowed_uri.scheme == parsed_uri.scheme
+            and parsed_allowed_uri.netloc == parsed_uri.netloc
+            and parsed_allowed_uri.path == parsed_uri.path
+        ):
+
+            aqs_set = set(parse_qsl(parsed_allowed_uri.query))
+            if aqs_set.issubset(uqs_set):
+                return True
+
+    return False

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -133,6 +133,7 @@ class AbstractApplication(models.Model):
             if (
                 parsed_allowed_uri.scheme == parsed_uri.scheme == "http"
                 and parsed_uri.hostname in ["127.0.0.1", "::1"]
+                and isinstance(parsed_allowed_uri.port, type(None))
                 and parsed_allowed_uri.hostname == parsed_uri.hostname
                 and parsed_allowed_uri.path == parsed_uri.path
             ) or (


### PR DESCRIPTION
## Description of the Change
Allow loopback redirect URIs with ports using http scheme and localhost addresses (127.0.0.1 or ::1),
as described in RFC8252 (section 7.3).

## Checklist
- [X] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
