### PR TITLE
Fix double oauth2_provider mountpoint in oidc view

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@ Hiroki Kiyohara
 Jens Timmerman
 Jerome Leclanche
 Jim Graham
+Jonas Nygaard Pedersen
 Jonathan Steffan
 Jun Zhou
 Kristian Rune Larsen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * #524 Restrict usage of timezone aware expire dates to Django projects with USE_TZ set to True.
-* #955 Avoid doubling of `oauth2_provider` urls mountpath in json response for OIDC view `ConnectDiscoveryInfoView`
+* #955 Avoid doubling of `oauth2_provider` urls mountpath in json response for OIDC view `ConnectDiscoveryInfoView`.
+  Breaks existing OIDC discovery output
 
 ## [1.5.0] 2021-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * #712, #636, #808. Calls to `django.contrib.auth.authenticate()` now pass a `request`
   to provide compatibility with backends that need one.
-  
+
 ### Fixed
 * #524 Restrict usage of timezone aware expire dates to Django projects with USE_TZ set to True.
+* #955 Avoid doubling of `oauth2_provider` urls mountpath in json response for OIDC view `ConnectDiscoveryInfoView`
 
 ## [1.5.0] 2021-03-18
 

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -1,4 +1,5 @@
 import json
+from urllib.parse import urlparse
 
 from django.http import HttpResponse, JsonResponse
 from django.urls import reverse
@@ -32,12 +33,15 @@ class ConnectDiscoveryInfoView(OIDCOnlyMixin, View):
             )
             jwks_uri = request.build_absolute_uri(reverse("oauth2_provider:jwks-info"))
         else:
-            authorization_endpoint = "{}{}".format(issuer_url, reverse("oauth2_provider:authorize"))
-            token_endpoint = "{}{}".format(issuer_url, reverse("oauth2_provider:token"))
+            parsed_url = urlparse(oauth2_settings.OIDC_ISS_ENDPOINT)
+            host = parsed_url.scheme + "://" + parsed_url.netloc
+            authorization_endpoint = "{}{}".format(host, reverse("oauth2_provider:authorize"))
+            token_endpoint = "{}{}".format(host, reverse("oauth2_provider:token"))
             userinfo_endpoint = oauth2_settings.OIDC_USERINFO_ENDPOINT or "{}{}".format(
-                issuer_url, reverse("oauth2_provider:user-info")
+                host, reverse("oauth2_provider:user-info")
             )
-            jwks_uri = "{}{}".format(issuer_url, reverse("oauth2_provider:jwks-info"))
+            jwks_uri = "{}{}".format(host, reverse("oauth2_provider:jwks-info"))
+
         signing_algorithms = [Application.HS256_ALGORITHM]
         if oauth2_settings.OIDC_RSA_PRIVATE_KEY:
             signing_algorithms = [Application.RS256_ALGORITHM, Application.HS256_ALGORITHM]

--- a/tests/presets.py
+++ b/tests/presets.py
@@ -9,8 +9,8 @@ DEFAULT_SCOPES_RW = {"DEFAULT_SCOPES": ["read", "write"]}
 DEFAULT_SCOPES_RO = {"DEFAULT_SCOPES": ["read"]}
 OIDC_SETTINGS_RW = {
     "OIDC_ENABLED": True,
-    "OIDC_ISS_ENDPOINT": "http://localhost",
-    "OIDC_USERINFO_ENDPOINT": "http://localhost/userinfo/",
+    "OIDC_ISS_ENDPOINT": "http://localhost/o",
+    "OIDC_USERINFO_ENDPOINT": "http://localhost/o/userinfo/",
     "OIDC_RSA_PRIVATE_KEY": settings.OIDC_RSA_PRIVATE_KEY,
     "SCOPES": {
         "read": "Reading scope",

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -12,10 +12,10 @@ from . import presets
 class TestConnectDiscoveryInfoView(TestCase):
     def test_get_connect_discovery_info(self):
         expected_response = {
-            "issuer": "http://localhost",
+            "issuer": "http://localhost/o",
             "authorization_endpoint": "http://localhost/o/authorize/",
             "token_endpoint": "http://localhost/o/token/",
-            "userinfo_endpoint": "http://localhost/userinfo/",
+            "userinfo_endpoint": "http://localhost/o/userinfo/",
             "jwks_uri": "http://localhost/o/.well-known/jwks.json",
             "response_types_supported": [
                 "code",


### PR DESCRIPTION
## Fixes the doubling of mountpoint path in the OIDC endpoints values for `.well-known/openid-configuration/`

According to the `django-oauth-toolkit` documentation for [OIDC_ISS_ENDPOINT](https://django-oauth-toolkit.readthedocs.io/en/latest/settings.html#oidc-iss-endpoint) this settings variable should enable discovery at `OIDC_ISS_ENDPOINT` + `/.well-known/openid-configuration/`. This behaviour is backed by the OIDC [specs](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig).

But if you use the variable as described you'll end up with the correct URL for the `issuer` value but incorrect URL's for the values of `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, and `jwks_uri` in the json response when calling `/.well-known/openid-configuration/`. 

So if the `OIDC_ISS_ENDPOINT` is `http://localhost:8001/some-initial-path/o` the `issuer` will be `http://localhost:8001/some-initial-path/o` but `authorization_endpoint` will be `http://localhost:8001/some-initial-path/o/some-initial-path/o/authorize/`. Same pattern for `token_endpoint`, `userinfo_endpoint`, and `jwks_uri`

<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #955 

## Description of the Change
Instead of concatting `OIDC_ISS_ENDPOINT` with the output of`reverse` for the different OIDC views, first use `urlparse` to strip `OIDC_ISS_ENDPOINT` to only scheme + netloc (eg. `http` + `://` + `localhost:8000`).
Also updates tests to expect an `OIDC_ISS_ENDPOINT` that ends in `/o`.
## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
