### PR TITLE
Handles ValueErrors with invalid hex values in query strings (#954)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ Abhishek Patel
 Alan Crosswell
 Aleksander Vaskevich
 Alessandro De Angelis
+Alex Szabó
 Allisson Azevedo
 Anvesh Agarwal
 Aristóbulo Meneses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * #712, #636, #808. Calls to `django.contrib.auth.authenticate()` now pass a `request`
   to provide compatibility with backends that need one.
-  
+
 ### Fixed
 * #524 Restrict usage of timezone aware expire dates to Django projects with USE_TZ set to True.
+* #954 Query strings with invalid hex values now raise a SuspiciousOperation exception
 
 ## [1.5.0] 2021-03-18
 

--- a/oauth2_provider/backends.py
+++ b/oauth2_provider/backends.py
@@ -17,8 +17,8 @@ class OAuth2Backend:
         if request is not None:
             try:
                 valid, request = OAuthLibCore.verify_request(request, scopes=[])
-            except ValueError as err:
-                raise SuspiciousOperation(err)
+            except ValueError as error:
+                raise SuspiciousOperation(error)
             else:
                 if valid:
                     return request.user

--- a/oauth2_provider/backends.py
+++ b/oauth2_provider/backends.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.core.exceptions import SuspiciousOperation
 
 from .oauth2_backends import get_oauthlib_core
 
@@ -14,9 +15,14 @@ class OAuth2Backend:
 
     def authenticate(self, request=None, **credentials):
         if request is not None:
-            valid, r = OAuthLibCore.verify_request(request, scopes=[])
-            if valid:
-                return r.user
+            try:
+                valid, request = OAuthLibCore.verify_request(request, scopes=[])
+            except ValueError as err:
+                raise SuspiciousOperation(err)
+            else:
+                if valid:
+                    return request.user
+
         return None
 
     def get_user(self, user_id):

--- a/oauth2_provider/views/mixins.py
+++ b/oauth2_provider/views/mixins.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from django.http import HttpResponseForbidden, HttpResponseNotFound
 
 from ..exceptions import FatalClientError
@@ -150,7 +150,11 @@ class OAuthLibMixin:
         :param request: The current django.http.HttpRequest object
         """
         core = self.get_oauthlib_core()
-        return core.verify_request(request, scopes=self.get_scopes())
+
+        try:
+            return core.verify_request(request, scopes=self.get_scopes())
+        except ValueError as error:
+            raise SuspiciousOperation(error)
 
     def get_scopes(self):
         """


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #954

## Description of the Change
Invalid hex values result in HTTP 500 errors, the purpose of this PR is to convert them to HTTP 400 ones.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [X] PR only contains one change (considered splitting up PR)
- [X] unit-test added
- [ ] documentation updated
- [X] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`

