### PR TITLE
WIP: Don't assume it's a Bearer token in Authorization header

### DIFF
--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -196,8 +196,12 @@ class OAuthLibCore:
         :param scopes: A list of scopes required to verify so that request is verified
         """
         uri, http_method, body, headers = self._extract_params(request)
-
-        valid, r = self.server.verify_request(uri, http_method, body, headers, scopes=scopes)
+        # Oauthlib has an assumption (without confirming) that the only kind of Authorization header is a Bearer.
+        # It's entirely possible to have multiple authentication classes that include Basic as well. See #964.
+        if "Authorization" in headers and headers["Authorization"].startswith("Bearer "):
+            valid, r = self.server.verify_request(uri, http_method, body, headers, scopes=scopes)
+        else:
+            valid, r = False, None
         return valid, r
 
     def authenticate_client(self, request):


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #964

## Description of the Change
Make sure the Authorization header contains a Bearer token; a Basic token causes the OIDC jwt parser to blow up.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
