### PR TITLE
Use django-cors-headers in docs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Alan Crosswell
 Aleksander Vaskevich
 Alessandro De Angelis
 Allisson Azevedo
+Andrew Chen Wang
 Anvesh Agarwal
 Aristóbulo Meneses
 Aryan Iyappan

--- a/docs/tutorial/tutorial_01.rst
+++ b/docs/tutorial/tutorial_01.rst
@@ -9,14 +9,14 @@ Start Your App
 --------------
 During this tutorial you will make an XHR POST from a Heroku deployed app to your localhost instance.
 Since the domain that will originate the request (the app on Heroku) is different from the destination domain (your local instance),
-you will need to install the `django-cors-middleware <https://github.com/zestedesavoir/django-cors-middleware>`_ app.
+you will need to install the `django-cors-headers <https://github.com/adamchainz/django-cors-headers>`_ app.
 These "cross-domain" requests are by default forbidden by web browsers unless you use `CORS <http://en.wikipedia.org/wiki/Cross-origin_resource_sharing>`_.
 
-Create a virtualenv and install `django-oauth-toolkit` and `django-cors-middleware`:
+Create a virtualenv and install `django-oauth-toolkit` and `django-cors-headers`:
 
 ::
 
-    pip install django-oauth-toolkit django-cors-middleware
+    pip install django-oauth-toolkit django-cors-headers
 
 Start a Django project, add `oauth2_provider` and `corsheaders` to the installed apps, and enable admin:
 


### PR DESCRIPTION
References #411 

## Description of the Change

Change docs to use django-cors-headers instead of django-cors-middleware which has been archived as a repo. Django-cors-headers resumed maintenance.

Besides installation, INSTALLED_APPS and the rest stays the same (since django-cors-middleware was a fork).

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [X] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [X] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
