### PR TITLE
Client credentials app throws assertion on auth code flow

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,6 +44,7 @@ Jozef Knaperek
 Jun Zhou
 Kristian Rune Larsen
 Michael Howitz
+Panos Angelopoulos
 Paul Dekkers
 Paul Oswald
 Pavel Tvrdík

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
   -->
 
+
 ## [Unreleased]
 ### Added
 * #651 Batch expired token deletions in `cleartokens` management command
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * #1012 Return status for introspecting a nonexistent token from 401 to the correct value of 200 per [RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2).
+* #974 Return 400 error in case of wrong client type rather than a 500 error.
 
 ## [1.6.1] 2021-12-23
 

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -15,7 +15,7 @@ from django.contrib.auth.hashers import check_password
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.models import Q
-from django.http import HttpRequest
+from django.http import HttpRequest, HttpResponseBadRequest
 from django.utils import dateformat, timezone
 from django.utils.timezone import make_aware
 from django.utils.translation import gettext_lazy as _
@@ -300,7 +300,10 @@ class OAuth2Validator(RequestValidator):
         return self._load_application(client_id, request) is not None
 
     def get_default_redirect_uri(self, client_id, request, *args, **kwargs):
-        return request.client.default_redirect_uri
+        try:
+            return request.client.default_redirect_uri
+        except Exception as e:
+            raise HttpResponseBadRequest(e)
 
     def _get_token_from_authentication_server(
         self, token, introspection_url, introspection_token, introspection_credentials

--- a/tests/test_auth_backends.py
+++ b/tests/test_auth_backends.py
@@ -162,3 +162,12 @@ class TestOAuth2Middleware(BaseTest):
         response = m(request)
         self.assertIn("Vary", response)
         self.assertIn("Authorization", response["Vary"])
+
+    def test_get_default_redirect_uri_empty_redirect_uri_raise_exception(self):
+        self.application.authorization_grant_type = Application.GRANT_AUTHORIZATION_CODE
+        self.application.redirect_uris = None
+
+        with self.assertRaises(Exception):
+            self.validator.get_default_redirect_uri(
+                client_id=self.application.client_id, request=self.request
+            )

--- a/tests/test_auth_backends.py
+++ b/tests/test_auth_backends.py
@@ -164,7 +164,7 @@ class TestOAuth2Middleware(BaseTest):
         self.assertIn("Authorization", response["Vary"])
 
     def test_get_default_redirect_uri_empty_redirect_uri_raise_exception(self):
-        self.application.authorization_grant_type = Application.GRANT_AUTHORIZATION_CODE
+        self.application.authorization_grant_type = ApplicationModel.GRANT_AUTHORIZATION_CODE
         self.application.redirect_uris = None
 
         with self.assertRaises(Exception):

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -4,7 +4,6 @@ import json
 
 import pytest
 from django.contrib.auth import get_user_model
-from django.http import HttpResponseBadRequest
 from django.test import TestCase, TransactionTestCase
 from django.utils import timezone
 from jwcrypto import jwt

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.http import HttpResponseBadRequest
 from django.test import TestCase, TransactionTestCase
 from django.utils import timezone
 from jwcrypto import jwt


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #958

## Description of the Change

If you try and use a client credentials app as an authorization code app flow it will cause an assertion error to be thrown, with this PR the return response has 400 status code.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [X] PR only contains one change (considered splitting up PR)
- [X] unit-test added
- [ ] documentation updated
- [X] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
