### PR TITLE
Add missing import

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ Jonas Nygaard Pedersen
 Jonathan Steffan
 Jun Zhou
 Kristian Rune Larsen
+Michael Howitz
 Paul Dekkers
 Paul Oswald
 Pavel Tvrdík

--- a/docs/tutorial/tutorial_01.rst
+++ b/docs/tutorial/tutorial_01.rst
@@ -33,6 +33,8 @@ Include the Django OAuth Toolkit urls in your `urls.py`, choosing the urlspace y
 
 .. code-block:: python
 
+    from django.urls import path, include
+
     urlpatterns = [
         path("admin", admin.site.urls),
         path("o/", include('oauth2_provider.urls', namespace='oauth2_provider')),


### PR DESCRIPTION
## Description of the Change

In a newly created Django project (version 3.2.1) the `include` function is not imported.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [X] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [X] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
