### PR TITLE
Require redirect_uri if multiple URIs are registered

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@ David Smith
 Diego Garcia
 Dulmandakh Sukhbaatar
 Dylan Giesler
+Dylan Tack
 Emanuele Palazzetti
 Federico Dolce
 Frederico Vieira

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from jwcrypto import jwk
 from jwcrypto.common import base64url_encode
+from oauthlib.oauth2.rfc6749 import errors
 
 from .generators import generate_client_id, generate_client_secret
 from .scopes import get_scopes_backend
@@ -107,11 +108,13 @@ class AbstractApplication(models.Model):
     @property
     def default_redirect_uri(self):
         """
-        Returns the default redirect_uri extracting the first item from
-        the :attr:`redirect_uris` string
+        Returns the default redirect_uri, *if* only one is registered.
         """
         if self.redirect_uris:
-            return self.redirect_uris.split().pop(0)
+            uris = self.redirect_uris.split()
+            if len(uris) == 1:
+                return self.redirect_uris.split().pop(0)
+            raise errors.MissingRedirectURIError()
 
         assert False, (
             "If you are using implicit, authorization_code"

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -370,6 +370,8 @@ class TestHybridView(BaseTest):
         Test for default redirect uri if omitted from query string with response_type: code
         """
         self.client.login(username="hy_test_user", password="123456")
+        self.application.redirect_uris = "http://localhost"
+        self.application.save()
 
         query_string = urlencode(
             {
@@ -413,6 +415,7 @@ class TestHybridView(BaseTest):
             {
                 "client_id": self.application.client_id,
                 "response_type": "WRONG",
+                "redirect_uri": "http://example.org",
             }
         )
         url = "{url}?{qs}".format(url=reverse("oauth2_provider:authorize"), qs=query_string)

--- a/tests/test_implicit.py
+++ b/tests/test_implicit.py
@@ -110,6 +110,8 @@ class TestImplicitAuthorizationCodeView(BaseTest):
         Test for default redirect uri if omitted from query string with response_type: token
         """
         self.client.login(username="test_user", password="123456")
+        self.application.redirect_uris = "http://localhost"
+        self.application.save()
 
         query_data = {
             "client_id": self.application.client_id,


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->

## Description of the Change
https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2.3

> If multiple redirection URIs have been registered... the client MUST include a redirection URI with the authorization request using the "redirect_uri" request parameter.

This fixes a bug where the _first_ registered URI was used as the default.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ x ] PR only contains one change (considered splitting up PR)
- [ x ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ x ] author name in `AUTHORS`
