### PR TITLE
Add missing space in assertion error

### DIFF
--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -114,7 +114,7 @@ class AbstractApplication(models.Model):
             return self.redirect_uris.split().pop(0)
 
         assert False, (
-            "If you are using implicit, authorization_code"
+            "If you are using implicit, authorization_code "
             "or all-in-one grant_type, you must define "
             "redirect_uris field in your Application model"
         )


### PR DESCRIPTION
Add a space to multi-line string so the words "authorization_code" and "or" are properly separated