### PR TITLE
Not existing tokens should return 200 within introspection (not 403)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,6 +47,7 @@ Michael Howitz
 Paul Dekkers
 Paul Oswald
 Pavel Tvrdík
+Patrick Palacin
 Peter Carnesciali
 Petr Dlouhý
 Rodney Richardson

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 * #651 Batch expired token deletions in `cleartokens` management command
-
-### Added
-
 * Added pt-BR translations.
+
+### Fixed
+* #1012 Return status for introspecting a nonexistent token from 401 to the correct value of 200 per [RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2).
 
 ## [1.6.1] 2021-12-23
 

--- a/oauth2_provider/views/introspect.py
+++ b/oauth2_provider/views/introspect.py
@@ -28,7 +28,7 @@ class IntrospectTokenView(ClientProtectedScopedResourceView):
                 get_access_token_model().objects.select_related("user", "application").get(token=token_value)
             )
         except ObjectDoesNotExist:
-            return JsonResponse({"active": False}, status=401)
+            return JsonResponse({"active": False}, status=200)
         else:
             if token.is_valid():
                 data = {
@@ -42,7 +42,7 @@ class IntrospectTokenView(ClientProtectedScopedResourceView):
                     data["username"] = token.user.get_username()
                 return JsonResponse(data)
             else:
-                return JsonResponse({"active": False})
+                return JsonResponse({"active": False}, status=200)
 
     def get(self, request, *args, **kwargs):
         """

--- a/tests/test_introspection_view.py
+++ b/tests/test_introspection_view.py
@@ -199,7 +199,7 @@ class TestTokenIntrospectionViews(TestCase):
             reverse("oauth2_provider:introspect"), {"token": "kaudawelsch"}, **auth_headers
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 200)
         content = response.json()
         self.assertIsInstance(content, dict)
         self.assertDictEqual(
@@ -269,7 +269,7 @@ class TestTokenIntrospectionViews(TestCase):
             reverse("oauth2_provider:introspect"), {"token": "kaudawelsch"}, **auth_headers
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 200)
         content = response.json()
         self.assertIsInstance(content, dict)
         self.assertDictEqual(


### PR DESCRIPTION
Compare with https://datatracker.ietf.org/doc/html/rfc7662

<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #

## Description of the Change

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
