### PR TITLE
Update tutorial_03.rst to use arrays instead of tuples in the settings.py file

### DIFF
--- a/docs/tutorial/tutorial_03.rst
+++ b/docs/tutorial/tutorial_03.rst
@@ -15,21 +15,21 @@ which takes care of token verification. In your settings.py:
 
 .. code-block:: python
 
-    AUTHENTICATION_BACKENDS = (
+    AUTHENTICATION_BACKENDS = [
         'oauth2_provider.backends.OAuth2Backend',
         # Uncomment following if you want to access the admin
-        #'django.contrib.auth.backends.ModelBackend'
+        #'django.contrib.auth.backends.ModelBackend',
         '...',
-    )
+    ]
 
-    MIDDLEWARE = (
+    MIDDLEWARE = [
         '...',
         # If you use SessionAuthenticationMiddleware, be sure it appears before OAuth2TokenMiddleware.
         # SessionAuthenticationMiddleware is NOT required for using django-oauth-toolkit.
         'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
         'oauth2_provider.middleware.OAuth2TokenMiddleware',
         '...',
-    )
+    ]
 
 You will likely use the `django.contrib.auth.backends.ModelBackend` along with the OAuth2 backend
 (or you might not be able to log in into the admin), only pay attention to the order in which


### PR DESCRIPTION
`AUTHENTICATION_BACKENDS` and `MIDDLEWARE` should be arrays, not tuples. Using tuples seems to work, but everything else in the settings.py file is an array.

<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #

## Description of the Change

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ ] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
