### PR TITLE
Replaced pkg_resources usage with importlib.metadata

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -60,3 +60,4 @@ Jadiel Teófilo
 pySilver
 Łukasz Skarżyński
 Shaheed Haque
+Vinay Karanam

--- a/oauth2_provider/__init__.py
+++ b/oauth2_provider/__init__.py
@@ -1,6 +1,9 @@
-import pkg_resources
+try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
 
 
-__version__ = pkg_resources.require("django-oauth-toolkit")[0].version
+__version__ = version("django-oauth-toolkit")
 
 default_app_config = "oauth2_provider.apps.DOTConfig"

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
 	requests >= 2.13.0
 	oauthlib >= 3.1.0
 	jwcrypto >= 0.8.0
+	importlib-metadata; python_version < "3.8"
 	six
 
 [options.packages.find]


### PR DESCRIPTION
## Description of the Change
Replaced pkg_resources usage with importlib.metadata

Setuptools discourages use of pkg_resources in favour of importlib.resources and importlib.metadata. (Ref: [pkg_resources](https://setuptools.pypa.io/en/latest/pkg_resources.html))

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added (Not required)
- [x] documentation updated (Not required)
- [x] `CHANGELOG.md` updated (only for user relevant changes) (Not required)
- [x] author name in `AUTHORS`
