### PR TITLE
Moved version info from setup.cfg into package

### DIFF
--- a/oauth2_provider/__init__.py
+++ b/oauth2_provider/__init__.py
@@ -1,9 +1,3 @@
-try:
-    from importlib.metadata import version
-except ImportError:
-    from importlib_metadata import version
-
-
-__version__ = version("django-oauth-toolkit")
+__version__ = "1.5.0"
 
 default_app_config = "oauth2_provider.apps.DOTConfig"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-oauth-toolkit
-version = 1.5.0
+version = attr: oauth2_provider.__version__
 description = OAuth2 Provider for Django
 long_description = file: README.rst
 long_description_content_type = text/x-rst
@@ -36,7 +36,6 @@ install_requires =
 	requests >= 2.13.0
 	oauthlib >= 3.1.0
 	jwcrypto >= 0.8.0
-	importlib-metadata; python_version < "3.8"
 
 [options.packages.find]
 exclude = tests


### PR DESCRIPTION
## Description of the Change

Moved version info from setup.cfg into package.
It is better to make setup.cfg infer version info from the package instead of vice versa.

Previous method only works where the package is "installed".
It doesn't work if we were to use this as a git submodule or frozen environments like nuitka.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added (Not required)
- [x] documentation updated (Not required)
- [x] `CHANGELOG.md` updated (only for user relevant changes) (Not required)
- [x] author name in `AUTHORS`
