### PR TITLE
Skip authentication for direct POST on endpoint

### DIFF
--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -127,7 +127,6 @@ class AuthorizationView(BaseAuthorizationView, FormView):
             credentials["claims"] = form.cleaned_data.get("claims")
 
         scopes = form.cleaned_data.get("scope")
-        
 
         if application.skip_authorization:
             allow = True

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -127,7 +127,12 @@ class AuthorizationView(BaseAuthorizationView, FormView):
             credentials["claims"] = form.cleaned_data.get("claims")
 
         scopes = form.cleaned_data.get("scope")
-        allow = form.cleaned_data.get("allow")
+        
+
+        if application.skip_authorization:
+            allow = True
+        else:
+            allow = form.cleaned_data.get("allow")
 
         try:
             uri, headers, body, status = self.create_authorization_response(


### PR DESCRIPTION
## Description of the Change
The solution fixes a problem of automation when user should get an authorization code to send it to a client to exchange to token(hashikorp vault in example).
```
curl -k -vvv -sXPOST "http://127.0.0.1:8000/authorize/"  -d"grant_type=authorization_code&response_type=code&client_id=testvault&username=xxx&password=xxx&redirect_uri=http://127.0.0.1:8000&scope=openid profile&allow=1"
```
will look like
```
curl -k -vvv -sXPOST "http://127.0.0.1:8000/authorize/"  -d"grant_type=authorization_code&response_type=code&client_id=testvault&username=xxx&password=xxx&redirect_uri=http://127.0.0.1:8000&scope=openid profile"
```
as it should.


## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
