### PR TITLE
Removes default_app_config for Django Deprecation Warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade tox tox-gh-actions
+        python -m pip install --upgrade tox tox-gh-actions django
 
     - name: Tox tests
       run: |

--- a/AUTHORS
+++ b/AUTHORS
@@ -46,6 +46,7 @@ Michael Howitz
 Paul Dekkers
 Paul Oswald
 Pavel Tvrdík
+Peter Carnesciali
 Rodney Richardson
 Rustem Saiargaliev
 Sandro Rodrigues

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 Django>=3.0,<3.1
 oauthlib>=3.1.0
 m2r>=0.2.1
+mistune<2
 .

--- a/oauth2_provider/__init__.py
+++ b/oauth2_provider/__init__.py
@@ -1,3 +1,6 @@
+import django
+
+
 __version__ = "1.5.0"
 
 if django.VERSION < (3, 2):

--- a/oauth2_provider/__init__.py
+++ b/oauth2_provider/__init__.py
@@ -1,1 +1,4 @@
 __version__ = "1.5.0"
+
+if django.VERSION < (3, 2):
+    default_app_config = "oauth2_provider.apps.DOTConfig"

--- a/oauth2_provider/__init__.py
+++ b/oauth2_provider/__init__.py
@@ -1,3 +1,1 @@
 __version__ = "1.5.0"
-
-default_app_config = "oauth2_provider.apps.DOTConfig"

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,7 @@ deps =
     sphinx<3
     oauthlib>=3.1.0
     m2r>=0.2.1
+    mistune<2
     sphinx-rtd-theme
     livedocs: sphinx-autobuild
     jwcrypto


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->

## Description of the Change
Fixes Django Deprecation Warning
`/usr/local/lib/python3.9/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'oauth2_provider' defines default_app_config = 'oauth2_provider.apps.DOTConfig'. Django now detects this configuration automatically. You can remove default_app_config.`
## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- N/A unit-test added
- N/A documentation updated
- N/A `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`

Confirmed that tox passed locally