### PR TITLE
support django 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   -->
 
 ## [Unreleased]
+* Fix Django 4.0.0 support
 
 ## [1.6.0] 2021-12-19
 ### Added

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Requirements
 ------------
 
 * Python 3.7+
-* Django 2.2, 3.2, or >=4.0.1
+* Django 2.2, 3.2, or >=4.0
 * oauthlib 3.1+
 
 Installation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 * Python 3.7+
-* Django 2.2, 3.2, 4.0.1+
+* Django 2.2, 3.2, 4.0+
 * oauthlib 3.1+
 
 Index

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ zip_safe = False
 # jwcrypto has a direct dependency on six, but does not list it yet in a release
 # Previously, cryptography also depended on six, so this was unnoticed
 install_requires =
-	django >= 2.2, != 4.0.0
+	django >= 2.2
 	requests >= 2.13.0
 	oauthlib >= 3.1.0
 	jwcrypto >= 0.8.0


### PR DESCRIPTION
## Description of the Change

When I try do install **django-oauth-toolkit** using Poetry I get following error. So this PR fixes django 4.0.0 support.

```python
SolverProblemError

  Because no versions of django-oauth-toolkit match >1.6.0,<2.0.0
   and django-oauth-toolkit (1.6.0) depends on django (>=2.2,<4.0.0 || >4.0.0), django-oauth-toolkit (>=1.6.0,<2.0.0) requires django (>=2.2,<4.0.0 || >4.0.0).
  And because no versions of django match >4.0.0,<5.0, django-oauth-toolkit (>=1.6.0,<2.0.0) requires Django (>=2.2,<4.0.0 || >=5.0).
  So, because backend depends on both Django (^4.0) and django-oauth-toolkit (^1.6.0), version solving failed.
```

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
