### PR TITLE
Move tox django dependency to proper place

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade tox tox-gh-actions django
+        python -m pip install --upgrade tox tox-gh-actions
 
     - name: Tox tests
       run: |

--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,7 @@ deps =
     sphinx-rtd-theme
     livedocs: sphinx-autobuild
     jwcrypto
+    django
 
 [testenv:flake8]
 basepython = python3.8


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->

## Description of the Change
In https://github.com/jazzband/django-oauth-toolkit/commit/345122881424897a2907312db52fafad9bbaa5f1, I added a tox dependency for django in the wrong place.
Very minor change, just adding it to tox.ini instead.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
