### PR TITLE
Remove Django pinning in doc requirements.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,15 +1,29 @@
-# .readthedocs.yml
+# .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+   configuration: docs/conf.py
 
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
 python:
-  version: 3.9
-  install:
-    - requirements: docs/requirements.txt
+   install:
+   - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,6 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.7
+  version: 3.9
   install:
     - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
-Django>=3.0,<3.1
+Django
 oauthlib>=3.1.0
 m2r>=0.2.1
 mistune<2
-.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ Django
 oauthlib>=3.1.0
 m2r>=0.2.1
 mistune<2
+-e .


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->

Fix #1049.

## Description of the Change

This will fix RTD installing conflicting Django versions.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
