### PR TITLE
Clarify why Django 4.0.0 isn't supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * #949 Provide django.contrib.auth.authenticate() with a `request` for compatibiity with more backends (like django-axes).
 * #968, #1039 Add support for Django 3.2 and 4.0.
+   * Note: Only Django 4.0.1+ is supported due to a regression in Django 4.0.0. [Explanation](https://github.com/jazzband/django-oauth-toolkit/pull/1046#issuecomment-998015272)
 * #953 Allow loopback redirect URIs using random ports as described in [RFC8252 section 7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3).
 * #972 Add Farsi/fa language support.
 * #978 OIDC: Add support for [rotating multiple RSA private keys](https://django-oauth-toolkit.readthedocs.io/en/latest/oidc.html#rotating-the-rsa-private-key).

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ capabilities to your Django projects. Django OAuth Toolkit makes extensive use o
 `OAuthLib <https://github.com/idan/oauthlib>`_, so that everything is
 `rfc-compliant <http://tools.ietf.org/html/rfc6749>`_.
 
-Note: If you have issues installing Django 4.0.0, it is because we only support 
+Note: If you have issues installing Django 4.0.0, it is because we only support
 Django 4.0.1+ due to a regression in Django 4.0.0. Besides 4.0.0, Django 2.2+ is supported.
 `Explanation <https://github.com/jazzband/django-oauth-toolkit/pull/1046#issuecomment-998015272>`.
 

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,10 @@ capabilities to your Django projects. Django OAuth Toolkit makes extensive use o
 `OAuthLib <https://github.com/idan/oauthlib>`_, so that everything is
 `rfc-compliant <http://tools.ietf.org/html/rfc6749>`_.
 
+Note: If you have issues installing Django 4.0.0, it is because we only support 
+Django 4.0.1+ due to a regression in Django 4.0.0. Besides 4.0.0, Django 2.2+ is supported.
+`Explanation <https://github.com/jazzband/django-oauth-toolkit/pull/1046#issuecomment-998015272>`.
+
 Contributing
 ------------
 


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1051 

## Description of the Change

Clarifies why Django 4.0.0 specifically isn't supported but 4.0.1 will be supported.

Updates README (for upfront dev purposes) and docs (updated CHANGELOG since that goes into our RTD for SEO/Google and RTD search engine purposes).

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [X] PR only contains one change (considered splitting up PR)
- [X] unit-test added
- [X] documentation updated
- [X] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
