### PR TITLE
Add migration due to noop FK from Django 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * #1012 Return status for introspecting a nonexistent token from 401 to the correct value of 200 per [RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2).
 * #1068 Revert #967 which incorrectly changed an API. See #1066.
+* #1056 Add missing migration triggered by [Django 4.0 changes to the migrations autodetector](https://docs.djangoproject.com/en/4.0/releases/4.0/#migrations-autodetector-changes).
 
 ## [1.6.1] 2021-12-23
 

--- a/oauth2_provider/migrations/0005_auto_20211222_2352.py
+++ b/oauth2_provider/migrations/0005_auto_20211222_2352.py
@@ -1,0 +1,39 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('oauth2_provider', '0004_auto_20200902_2022'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='accesstoken',
+            name='user',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='%(app_label)s_%(class)s', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AlterField(
+            model_name='application',
+            name='user',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='%(app_label)s_%(class)s', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AlterField(
+            model_name='grant',
+            name='user',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='%(app_label)s_%(class)s', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AlterField(
+            model_name='idtoken',
+            name='user',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='%(app_label)s_%(class)s', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AlterField(
+            model_name='refreshtoken',
+            name='user',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='%(app_label)s_%(class)s', to=settings.AUTH_USER_MODEL),
+        ),
+    ]


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->


## Description of the Change

I wanted to double check that 4.0.1 wouldn't create a new migration. Turns out, I missed a comment from the PR that mentions how a migration would still be created. The reason is because of the related_name using the placeholder itself now rather than using "oauth2_provider".

Fortunately, this migration isn't as drastic as the `auth.User` one which would have deleted data... Let me know if I'm missing anything else.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
