### PR TITLE
Replace RST header underline with one that pre-commit check-merge won't break on.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,11 +1,11 @@
 Authors
-=======
+-------
 
 Massimiliano Pippi
 Federico Frenguelli
 
 Contributors
-============
+------------
 
 Abhishek Patel
 Alan Crosswell


### PR DESCRIPTION

<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #

## Description of the Change
Workaround problem where the precommit merge hook breaks on the 7-character doulbe-underline for AUTHORS by having a false-positive broken commit error. 

It pains me to do this but I'd rather catch actual merge conflicts than exclude checking this file.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
