### PR TITLE
WIP: Feat/verify token exists before saving

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -64,4 +64,4 @@ pySilver
 Shaheed Haque
 Andrea Greco
 Vinay Karanam
-
+Wagner de Lima

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* Only saves AccessToken and RefreshToken -- at OAuth2Validator level -- if they do not exist in database or if they are
+expired or revoked.
+
 ## [1.6.1] 2021-12-23
 
 ### Changed

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -453,6 +453,15 @@ class AbstractRefreshToken(models.Model):
             self.revoked = timezone.now()
             self.save()
 
+    def is_expired(self):
+        """
+        Check token expiration with timezone awareness
+        """
+        if not self.revoked:
+            return False
+
+        return timezone.now() >= self.revoked
+
     def __str__(self):
         return self.token
 

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -607,10 +607,11 @@ class OAuth2Validator(RequestValidator):
         if id_token:
             id_token = self._load_id_token(id_token)
 
-        access_token = AccessToken.objects.select_for_update().filter(
-            user=request.user,
-            application=request.client,
-        ).last()
+        access_token = (
+            AccessToken.objects.select_for_update()
+            .filter(user=request.user, application=request.client,)
+            .last()
+        )
 
         # if there is no access token in the database for a specific user,
         # or there is an access token but it is expired, a new access token is created.

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -644,11 +644,11 @@ class OAuth2Validator(RequestValidator):
         )
 
     def _create_refresh_token(self, request, refresh_token_code, access_token):
-        refresh_token = RefreshToken.objects.select_for_update().filter(
-            user=request.user,
-            application=request.client,
-            access_token=access_token
-        ).last()
+        refresh_token = (
+            RefreshToken.objects.select_for_update()
+            .filter(user=request.user, application=request.client, access_token=access_token)
+            .last()
+        )
 
         # if there is no refresh_token associated with a user and application,
         # or there is a refresh token but it's revoked, a new refresh token is created.


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #
There is no issue associated with this project. However, at my framwork's list of issues you can find why I opened this pull request: https://github.com/wagnerdelima/drf-social-oauth2/issues/80#issuecomment-1000864361

## Description of the Change
Everytime save_bearer_token is called, a refresh token and access token is created. However, it's wise vefirying if they already exist in database and if they are valid (not expired or revoked). So, only then we create new tokens, otherwise, return the already existing tokens.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
