### PR TITLE
add pt_BR locale translation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -64,4 +64,4 @@ pySilver
 Shaheed Haque
 Andrea Greco
 Vinay Karanam
-
+Eduardo Oliveira

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Added pt-BR translations.
+
 ## [1.6.1] 2021-12-23
 
 ### Changed

--- a/oauth2_provider/locale/pt_BR/LC_MESSAGES/django.po
+++ b/oauth2_provider/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,202 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Eduardo Oliveira <eduardo_y05@outlook.com>, 2021.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-12-30 09:50-0300\n"
+"PO-Revision-Date: 2021-12-30 09:50-0300\n"
+"Last-Translator: Eduardo Oliveira <eduardo_y05@outlook.com>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: models.py:50
+msgid "Confidential"
+msgstr "Confidencial"
+
+#: models.py:51
+msgid "Public"
+msgstr "Público"
+
+#: models.py:60
+msgid "Authorization code"
+msgstr "Código de Autorização"
+
+#: models.py:61
+msgid "Implicit"
+msgstr "Implícito"
+
+#: models.py:62
+msgid "Resource owner password-based"
+msgstr "Baseado na senha do proprietário do recurso"
+
+#: models.py:63
+msgid "Client credentials"
+msgstr "Credenciais do cliente"
+
+#: models.py:64
+msgid "OpenID connect hybrid"
+msgstr "Híbrido de conexão OpenID"
+
+#: models.py:71
+msgid "No OIDC support"
+msgstr "Sem suporte a OIDC"
+
+#: models.py:72
+msgid "RSA with SHA-2 256"
+msgstr "RSA com SHA-2 256"
+
+#: models.py:73
+msgid "HMAC with SHA-2 256"
+msgstr "HMAC com SHA-2 256"
+
+#: models.py:88
+msgid "Allowed URIs list, space separated"
+msgstr "Lista de URLs permitidos, separados por espaço"
+
+#: models.py:155
+#, python-brace-format
+msgid "Unauthorized redirect scheme: {scheme}"
+msgstr "Esquema de redirecionamento não autorizado: {scheme}"
+
+#: models.py:159
+#, python-brace-format
+msgid "redirect_uris cannot be empty with grant_type {grant_type}"
+msgstr "redirect_uris não pode ser vázio com o grant_type {grant_type}"
+
+#: models.py:165
+msgid "You must set OIDC_RSA_PRIVATE_KEY to use RSA algorithm"
+msgstr "Você precisa definir OIDC_RSA_PRIVATE_KEY para usar o algoritmo RSA"
+
+#: models.py:174
+msgid "You cannot use HS256 with public grants or clients"
+msgstr "Você não pode usar HS256 com concessões publicas ou clientes"
+
+#: oauth2_validators.py:181
+msgid "The access token is invalid."
+msgstr "O token de acesso é inválido."
+
+#: oauth2_validators.py:188
+msgid "The access token has expired."
+msgstr "O token de acesso expirou."
+
+#: oauth2_validators.py:195
+msgid "The access token is valid but does not have enough scope."
+msgstr "O token de acesso é valido porém não tem o escopo necessário."
+
+#: templates/oauth2_provider/application_confirm_delete.html:6
+msgid "Are you sure to delete the application"
+msgstr "Tem certeza que deseja remover a aplicação?"
+
+#: templates/oauth2_provider/application_confirm_delete.html:12
+#: templates/oauth2_provider/authorize.html:29
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: templates/oauth2_provider/application_confirm_delete.html:13
+#: templates/oauth2_provider/application_detail.html:38
+#: templates/oauth2_provider/authorized-token-delete.html:7
+msgid "Delete"
+msgstr "Remover"
+
+#: templates/oauth2_provider/application_detail.html:10
+msgid "Client id"
+msgstr "ID do Cliente"
+
+#: templates/oauth2_provider/application_detail.html:15
+msgid "Client secret"
+msgstr "Palavra-Chave Secreta do Cliente"
+
+#: templates/oauth2_provider/application_detail.html:20
+msgid "Client type"
+msgstr "Tipo de Cliente"
+
+#: templates/oauth2_provider/application_detail.html:25
+msgid "Authorization Grant Type"
+msgstr "Tipo de concessão de autorização"
+
+#: templates/oauth2_provider/application_detail.html:30
+msgid "Redirect Uris"
+msgstr "URLs de redirecionamento"
+
+#: templates/oauth2_provider/application_detail.html:36
+#: templates/oauth2_provider/application_form.html:35
+msgid "Go Back"
+msgstr "Voltar"
+
+#: templates/oauth2_provider/application_detail.html:37
+msgid "Edit"
+msgstr "Editar"
+
+#: templates/oauth2_provider/application_form.html:9
+msgid "Edit application"
+msgstr "Editar Aplicação"
+
+#: templates/oauth2_provider/application_form.html:37
+msgid "Save"
+msgstr "Salvar"
+
+#: templates/oauth2_provider/application_list.html:6
+msgid "Your applications"
+msgstr "Suas Aplicações"
+
+#: templates/oauth2_provider/application_list.html:14
+msgid "New Application"
+msgstr "Nova Aplicação"
+
+#: templates/oauth2_provider/application_list.html:17
+msgid "No applications defined"
+msgstr "Não existem aplicações definidas"
+
+#: templates/oauth2_provider/application_list.html:17
+msgid "Click here"
+msgstr "Clicar aqui"
+
+#: templates/oauth2_provider/application_list.html:17
+msgid "if you want to register a new one"
+msgstr "se você deseja registrar uma nova"
+
+#: templates/oauth2_provider/application_registration_form.html:5
+msgid "Register a new application"
+msgstr "Registrar uma nova aplicação"
+
+#: templates/oauth2_provider/authorize.html:8
+#: templates/oauth2_provider/authorize.html:30
+msgid "Authorize"
+msgstr "Autorizar"
+
+#: templates/oauth2_provider/authorize.html:17
+msgid "Application requires the following permissions"
+msgstr "A Aplicação precisa das seguintes permissões"
+
+#: templates/oauth2_provider/authorized-oob.html:12
+msgid "Success"
+msgstr "Sucesso"
+
+#: templates/oauth2_provider/authorized-oob.html:14
+msgid "Please return to your application and enter this code:"
+msgstr "Por favor, retorne para a sua aplicação e insira o seguinte código:"
+
+#: templates/oauth2_provider/authorized-token-delete.html:6
+msgid "Are you sure you want to delete this token?"
+msgstr "Você tem certeza que deseja remover esse token?"
+
+#: templates/oauth2_provider/authorized-tokens.html:6
+msgid "Tokens"
+msgstr "Tokens"
+
+#: templates/oauth2_provider/authorized-tokens.html:11
+msgid "revoke"
+msgstr "Revogar"
+
+#: templates/oauth2_provider/authorized-tokens.html:19
+msgid "There are no authorized tokens yet."
+msgstr "Não existem tokens autorizados ainda."


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->

## Description of the Change

Add pt-BR locale translation (brazilian portuguese) for the django-oauth-toolkit application.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
