### PR TITLE
#1066: Revert #967 which incorrectly breaks API.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,6 +65,5 @@ pySilver
 Łukasz Skarżyński
 Shaheed Haque
 Peter Karman
-Andrea Greco
 Vinay Karanam
 Eduardo Oliveira

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * #1012 Return status for introspecting a nonexistent token from 401 to the correct value of 200 per [RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2).
+* #1068 Revert #967 which incorrectly changed an API. See #1066.
 
 ## [1.6.1] 2021-12-23
 

--- a/docs/oidc.rst
+++ b/docs/oidc.rst
@@ -245,17 +245,16 @@ required claims, eg ``iss``, ``aud``, ``exp``, ``iat``, ``auth_time`` etc),
 and the ``sub`` claim will use the primary key of the user as the value.
 You'll probably want to customize this and add additional claims or change
 what is sent for the ``sub`` claim. To do so, you will need to add a method to
-our custom validator.
-Standard claim ``sub`` is included by default, for remove it override ``get_claim_list``::
-    class CustomOAuth2Validator(OAuth2Validator):
-        def get_additional_claims(self):
-            def get_user_email(request):
-                return request.user.get_full_name()
+our custom validator::
 
-            # Element name, callback to obtain data
-            claims_list = [ ("email", get_sub_cod),
-                        ("username", get_user_email) ]
-            return claims_list
+    class CustomOAuth2Validator(OAuth2Validator):
+
+        def get_additional_claims(self, request):
+            return {
+                "sub": request.user.email,
+                "first_name": request.user.first_name,
+                "last_name": request.user.last_name,
+            }
 
 .. note::
     This ``request`` object is not a ``django.http.Request`` object, but an

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -740,24 +740,15 @@ class OAuth2Validator(RequestValidator):
     def get_jwt_bearer_token(self, token, token_handler, request):
         return self.get_id_token(token, token_handler, request)
 
-    def get_claim_list(self):
-        def get_sub_code(request):
-            return str(request.user.id)
-
-        list = [("sub", get_sub_code)]
+    def get_oidc_claims(self, token, token_handler, request):
+        # Required OIDC claims
+        claims = {
+            "sub": str(request.user.id),
+        }
 
         # https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
-        add = self.get_additional_claims()
-        list.extend(add)
+        claims.update(**self.get_additional_claims(request))
 
-        return list
-
-    def get_oidc_claims(self, token, token_handler, request):
-        data = self.get_claim_list()
-        claims = {}
-
-        for k, call in data:
-            claims[k] = call(request)
         return claims
 
     def get_id_token_dictionary(self, token, token_handler, request):
@@ -910,5 +901,5 @@ class OAuth2Validator(RequestValidator):
         """
         return self.get_oidc_claims(None, None, request)
 
-    def get_additional_claims(self):
-        return []
+    def get_additional_claims(self, request):
+        return {}

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -45,13 +45,6 @@ class ConnectDiscoveryInfoView(OIDCOnlyMixin, View):
         signing_algorithms = [Application.HS256_ALGORITHM]
         if oauth2_settings.OIDC_RSA_PRIVATE_KEY:
             signing_algorithms = [Application.RS256_ALGORITHM, Application.HS256_ALGORITHM]
-
-        validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
-        validator = validator_class()
-        oidc_claims = []
-        for el, _ in validator.get_claim_list():
-            oidc_claims.append(el)
-
         data = {
             "issuer": issuer_url,
             "authorization_endpoint": authorization_endpoint,
@@ -64,7 +57,6 @@ class ConnectDiscoveryInfoView(OIDCOnlyMixin, View):
             "token_endpoint_auth_methods_supported": (
                 oauth2_settings.OIDC_TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED
             ),
-            "claims_supported": oidc_claims,
         }
         response = JsonResponse(data)
         response["Access-Control-Allow-Origin"] = "*"

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -29,7 +29,6 @@ class TestConnectDiscoveryInfoView(TestCase):
             "subject_types_supported": ["public"],
             "id_token_signing_alg_values_supported": ["RS256", "HS256"],
             "token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"],
-            "claims_supported": ["sub"],
         }
         response = self.client.get(reverse("oauth2_provider:oidc-connect-discovery-info"))
         self.assertEqual(response.status_code, 200)
@@ -56,7 +55,6 @@ class TestConnectDiscoveryInfoView(TestCase):
             "subject_types_supported": ["public"],
             "id_token_signing_alg_values_supported": ["RS256", "HS256"],
             "token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"],
-            "claims_supported": ["sub"],
         }
         response = self.client.get(reverse("oauth2_provider:oidc-connect-discovery-info"))
         self.assertEqual(response.status_code, 200)
@@ -148,21 +146,11 @@ def test_userinfo_endpoint_bad_token(oidc_tokens, client):
     assert rsp.status_code == 401
 
 
-EXAMPLE_EMAIL = "example.email@example.com"
-
-
-def claim_user_email(request):
-    return EXAMPLE_EMAIL
-
-
 @pytest.mark.django_db
 def test_userinfo_endpoint_custom_claims(oidc_tokens, client, oauth2_settings):
     class CustomValidator(OAuth2Validator):
-        def get_additional_claims(self):
-            return [
-                ("username", claim_user_email),
-                ("email", claim_user_email),
-            ]
+        def get_additional_claims(self, request):
+            return {"state": "very nice"}
 
     oidc_tokens.oauth2_settings.OAUTH2_VALIDATOR_CLASS = CustomValidator
     auth_header = "Bearer %s" % oidc_tokens.access_token
@@ -173,9 +161,5 @@ def test_userinfo_endpoint_custom_claims(oidc_tokens, client, oauth2_settings):
     data = rsp.json()
     assert "sub" in data
     assert data["sub"] == str(oidc_tokens.user.pk)
-
-    assert "username" in data
-    assert data["username"] == EXAMPLE_EMAIL
-
-    assert "email" in data
-    assert data["email"] == EXAMPLE_EMAIL
+    assert "state" in data
+    assert data["state"] == "very nice"


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1066 

## Description of the Change
PR #967 should never have been merged as it changes the signature of a published API.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
