### PR TITLE
Add claims_supported to discovery info, without breaking the API

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -66,4 +66,5 @@ pySilver
 Shaheed Haque
 Vinay Karanam
 Eduardo Oliveira
+Andrea Greco
 Dominik George

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #651 Batch expired token deletions in `cleartokens` management command
 * Added pt-BR translations.
 * #1070 Add a Celery task for clearing expired tokens, e.g. to be scheduled as a [periodic task](https://docs.celeryproject.org/en/stable/userguide/periodic-tasks.html)
+* #1069 OIDC: Re-introduce [additional claims](https://django-oauth-toolkit.readthedocs.io/en/latest/oidc.html#adding-claims-to-the-id-token) beyond `sub` to the id_token.
 
 ### Fixed
 * #1012 Return status for introspecting a nonexistent token from 401 to the correct value of 200 per [RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2).

--- a/docs/oidc.rst
+++ b/docs/oidc.rst
@@ -245,16 +245,17 @@ required claims, eg ``iss``, ``aud``, ``exp``, ``iat``, ``auth_time`` etc),
 and the ``sub`` claim will use the primary key of the user as the value.
 You'll probably want to customize this and add additional claims or change
 what is sent for the ``sub`` claim. To do so, you will need to add a method to
-our custom validator::
-
+our custom validator.
+Standard claim ``sub`` is included by default, to remove it override ``get_claim_list``::
     class CustomOAuth2Validator(OAuth2Validator):
+        def get_additional_claims(self):
+            def get_user_email(request):
+                return request.user.get_full_name()
 
-        def get_additional_claims(self, request):
-            return {
-                "sub": request.user.email,
-                "first_name": request.user.first_name,
-                "last_name": request.user.last_name,
-            }
+            # Element name, callback to obtain data
+            claims_list = [ ("email", get_sub_cod),
+                        ("username", get_user_email) ]
+            return claims_list
 
 .. note::
     This ``request`` object is not a ``django.http.Request`` object, but an

--- a/docs/oidc.rst
+++ b/docs/oidc.rst
@@ -245,17 +245,22 @@ required claims, eg ``iss``, ``aud``, ``exp``, ``iat``, ``auth_time`` etc),
 and the ``sub`` claim will use the primary key of the user as the value.
 You'll probably want to customize this and add additional claims or change
 what is sent for the ``sub`` claim. To do so, you will need to add a method to
-our custom validator.
+our custom validator. It should return a dictionary mapping a claim name to
+either the claim data, or a callable that will be called with the request to
+produce the claim data.
 Standard claim ``sub`` is included by default, to remove it override ``get_claim_list``::
     class CustomOAuth2Validator(OAuth2Validator):
-        def get_additional_claims(self):
+        def get_additional_claims(self, request):
             def get_user_email(request):
-                return request.user.get_full_name()
+                return request.user.get_user_email()
 
+            claims = {}
             # Element name, callback to obtain data
-            claims_list = [ ("email", get_sub_cod),
-                        ("username", get_user_email) ]
-            return claims_list
+            claims["email"] = get_user_email
+            # Element name, plain data returned
+            claims["username"] = request.user.get_full_name()
+
+            return claims
 
 .. note::
     This ``request`` object is not a ``django.http.Request`` object, but an

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -728,15 +728,24 @@ class OAuth2Validator(RequestValidator):
     def get_jwt_bearer_token(self, token, token_handler, request):
         return self.get_id_token(token, token_handler, request)
 
-    def get_oidc_claims(self, token, token_handler, request):
-        # Required OIDC claims
-        claims = {
-            "sub": str(request.user.id),
-        }
+    def get_claim_list(self):
+        def get_sub_code(request):
+            return str(request.user.id)
+
+        list = [ ("sub", get_sub_code) ]
 
         # https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
-        claims.update(**self.get_additional_claims(request))
+        add = self.get_additional_claims()
+        list.extend(add)
 
+        return list
+
+    def get_oidc_claims(self, token, token_handler, request):
+        data = self.get_claim_list()
+        claims = {}
+
+        for k, call in data:
+            claims[k] = call(request)
         return claims
 
     def get_id_token_dictionary(self, token, token_handler, request):
@@ -889,5 +898,5 @@ class OAuth2Validator(RequestValidator):
         """
         return self.get_oidc_claims(None, None, request)
 
-    def get_additional_claims(self, request):
-        return {}
+    def get_additional_claims(self):
+        return []

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -728,24 +728,24 @@ class OAuth2Validator(RequestValidator):
     def get_jwt_bearer_token(self, token, token_handler, request):
         return self.get_id_token(token, token_handler, request)
 
-    def get_claim_list(self):
-        def get_sub_code(request):
-            return str(request.user.id)
+    def get_claim_dict(self, request):
+        def get_sub_code(inner_request):
+            return str(inner_request.user.id)
 
-        list = [ ("sub", get_sub_code) ]
+        claims = {"sub": get_sub_code}
 
         # https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
-        add = self.get_additional_claims()
-        list.extend(add)
+        add = self.get_additional_claims(request)
+        claims.update(add)
 
-        return list
+        return claims
 
     def get_oidc_claims(self, token, token_handler, request):
-        data = self.get_claim_list()
+        data = self.get_claim_dict(request)
         claims = {}
 
-        for k, call in data:
-            claims[k] = call(request)
+        for k, v in data.items():
+            claims[k] = v(request) if callable(v) else v
         return claims
 
     def get_id_token_dictionary(self, token, token_handler, request):
@@ -898,5 +898,5 @@ class OAuth2Validator(RequestValidator):
         """
         return self.get_oidc_claims(None, None, request)
 
-    def get_additional_claims(self):
-        return []
+    def get_additional_claims(self, request):
+        return {}

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -48,9 +48,7 @@ class ConnectDiscoveryInfoView(OIDCOnlyMixin, View):
 
         validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
         validator = validator_class()
-        oidc_claims = []
-        for el, _ in validator.get_claim_list():
-            oidc_claims.append(el)
+        oidc_claims = list(validator.get_claim_dict(request).keys())
 
         data = {
             "issuer": issuer_url,

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -48,9 +48,7 @@ class ConnectDiscoveryInfoView(OIDCOnlyMixin, View):
 
         validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
         validator = validator_class()
-        oidc_claims = validator.get_discovery_claims(request)
-        if "sub" not in oidc_claims:
-            oidc_claims.append("sub")
+        oidc_claims = list(set(validator.get_discovery_claims(request)))
 
         data = {
             "issuer": issuer_url,

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -48,7 +48,9 @@ class ConnectDiscoveryInfoView(OIDCOnlyMixin, View):
 
         validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
         validator = validator_class()
-        oidc_claims = list(validator.get_claim_dict(request).keys())
+        oidc_claims = validator.get_discovery_claims(request)
+        if "sub" not in oidc_claims:
+            oidc_claims.append("sub")
 
         data = {
             "issuer": issuer_url,

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -45,6 +45,13 @@ class ConnectDiscoveryInfoView(OIDCOnlyMixin, View):
         signing_algorithms = [Application.HS256_ALGORITHM]
         if oauth2_settings.OIDC_RSA_PRIVATE_KEY:
             signing_algorithms = [Application.RS256_ALGORITHM, Application.HS256_ALGORITHM]
+
+        validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
+        validator = validator_class()
+        oidc_claims = []
+        for el, _ in validator.get_claim_list():
+            oidc_claims.append(el)
+
         data = {
             "issuer": issuer_url,
             "authorization_endpoint": authorization_endpoint,
@@ -57,6 +64,7 @@ class ConnectDiscoveryInfoView(OIDCOnlyMixin, View):
             "token_endpoint_auth_methods_supported": (
                 oauth2_settings.OIDC_TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED
             ),
+            "claims_supported": oidc_claims,
         }
         response = JsonResponse(data)
         response["Access-Control-Allow-Origin"] = "*"

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -158,7 +158,7 @@ def claim_user_email(request):
 @pytest.mark.django_db
 def test_userinfo_endpoint_custom_claims_callable(oidc_tokens, client, oauth2_settings):
     class CustomValidator(OAuth2Validator):
-        def get_additional_claims(self, request):
+        def get_additional_claims(self):
             return {
                 "username": claim_user_email,
                 "email": claim_user_email,

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -156,13 +156,39 @@ def claim_user_email(request):
 
 
 @pytest.mark.django_db
-def test_userinfo_endpoint_custom_claims(oidc_tokens, client, oauth2_settings):
+def test_userinfo_endpoint_custom_claims_callable(oidc_tokens, client, oauth2_settings):
     class CustomValidator(OAuth2Validator):
-        def get_additional_claims(self):
-            return [
-                ("username", claim_user_email),
-                ("email", claim_user_email),
-            ]
+        def get_additional_claims(self, request):
+            return {
+                "username": claim_user_email,
+                "email": claim_user_email,
+            }
+
+    oidc_tokens.oauth2_settings.OAUTH2_VALIDATOR_CLASS = CustomValidator
+    auth_header = "Bearer %s" % oidc_tokens.access_token
+    rsp = client.get(
+        reverse("oauth2_provider:user-info"),
+        HTTP_AUTHORIZATION=auth_header,
+    )
+    data = rsp.json()
+    assert "sub" in data
+    assert data["sub"] == str(oidc_tokens.user.pk)
+
+    assert "username" in data
+    assert data["username"] == EXAMPLE_EMAIL
+
+    assert "email" in data
+    assert data["email"] == EXAMPLE_EMAIL
+
+
+@pytest.mark.django_db
+def test_userinfo_endpoint_custom_claims_plain(oidc_tokens, client, oauth2_settings):
+    class CustomValidator(OAuth2Validator):
+        def get_additional_claims(self, request):
+            return {
+                "username": EXAMPLE_EMAIL,
+                "email": EXAMPLE_EMAIL,
+            }
 
     oidc_tokens.oauth2_settings.OAUTH2_VALIDATOR_CLASS = CustomValidator
     auth_header = "Bearer %s" % oidc_tokens.access_token


### PR DESCRIPTION
** Please do not squash the commits. I analyse my FOSS contributions automatically and really want to track commits I made.**

## Description of the Change

This is a second shot at #967, after the drama with #1066 and #1068 ;).

It re-introduces the same change @AndreaGreco proposed, and in fact, it supports their exact desired API for `get_additional_claims`. In addition, it supports the "traditional" API for `get_additional_claims` getting passed a request directly and producing data directly.

I chose to support both due to the rationale explained in the docs in this PR.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
