### PR TITLE
Add Celery task for cleantokens

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -66,3 +66,4 @@ pySilver
 Shaheed Haque
 Vinay Karanam
 Eduardo Oliveira
+Dominik George

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * #651 Batch expired token deletions in `cleartokens` management command
 * Added pt-BR translations.
+* #1070 Add a Celery task for clearing expired tokens, e.g. to be scheduled as a [periodic task](https://docs.celeryproject.org/en/stable/userguide/periodic-tasks.html)
 
 ### Fixed
 * #1012 Return status for introspecting a nonexistent token from 401 to the correct value of 200 per [RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2).

--- a/docs/management_commands.rst
+++ b/docs/management_commands.rst
@@ -21,3 +21,8 @@ To prevent the CPU and RAM high peaks during deletion process use ``CLEAR_EXPIRE
 
 Note: Refresh tokens need to expire before AccessTokens can be removed from the
 database. Using ``cleartokens`` without ``REFRESH_TOKEN_EXPIRE_SECONDS`` has limited effect.
+
+The ``cleartokens`` action can also be scheduled as a `Celery periodic task`_
+by using the ``clear_tokens`` task (automatically registered when using Celery).
+
+.. _Celery periodic task: https://docs.celeryproject.org/en/stable/userguide/periodic-tasks.html

--- a/oauth2_provider/tasks.py
+++ b/oauth2_provider/tasks.py
@@ -1,0 +1,8 @@
+from celery import shared_task
+
+
+@shared_task
+def clear_tokens():
+    from ...models import clear_expired  # noqa
+
+    clear_expired()


### PR DESCRIPTION
## Description of the Change

This adds a Celery task to clean expired tokens. It can be used to schedule token cleanup in the background, for applications using Celery and Celery beat.

The `tasks` module is autodiscovered in projects that use Celery, and should not be loaded in other projects, so this does not introduce any new dependency,

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
