### PR TITLE
Issue 1087/default batch interval

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -345,9 +345,12 @@ The size of delete batches used by ``cleartokens`` management command.
 
 CLEAR_EXPIRED_TOKENS_BATCH_INTERVAL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Default: ``0.1``
+Default: ``0``
 
 Time of sleep in seconds used by ``cleartokens`` management command between batch deletions.
+
+Set this to a non-zero value (e.g. `0.1`) to add a pause between batch sizes to reduce system
+load when clearing large batches of expired tokens.
 
 
 Settings imported from Django project

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -102,7 +102,7 @@ DEFAULTS = {
     # Should only be required in testing.
     "ALWAYS_RELOAD_OAUTHLIB_CORE": False,
     "CLEAR_EXPIRED_TOKENS_BATCH_SIZE": 10000,
-    "CLEAR_EXPIRED_TOKENS_BATCH_INTERVAL": 0.1,
+    "CLEAR_EXPIRED_TOKENS_BATCH_INTERVAL": 0,
 }
 
 # List of settings that cannot be empty


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1087

## Description of the Change
Sets the default value time to pause between iterations of batch clear_expired tokens to zero.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
