### PR TITLE
Accept oob values as valid redirect URIs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,6 +21,7 @@ Ash Christopher
 Asif Saif Uddin
 Bart Merenda
 Bas van Oostveen
+Dan LaManna
 Dave Burkholder
 David Fischer
 David Smith

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * #1012 Return status for introspecting a nonexistent token from 401 to the correct value of 200 per [RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2).
+* #971 Allow nonstandard out of band (oob) redirect URIs to be set through administration forms.
 
 ## [1.6.3] 2022-01-11
 

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -183,7 +183,7 @@ class AbstractApplication(models.Model):
         By default, returns `ALLOWED_REDIRECT_URI_SCHEMES`.
         """
         # Manually tack urn on to allowed schemes so oob URIs continue to work
-        return oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES + ['urn']
+        return oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES + ["urn"]
 
     def allows_grant_type(self, *grant_types):
         return self.authorization_grant_type in grant_types

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -182,7 +182,8 @@ class AbstractApplication(models.Model):
         Returns the list of redirect schemes allowed by the Application.
         By default, returns `ALLOWED_REDIRECT_URI_SCHEMES`.
         """
-        return oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES
+        # Manually tack urn on to allowed schemes so oob URIs continue to work
+        return oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES + ['urn']
 
     def allows_grant_type(self, *grant_types):
         return self.authorization_grant_type in grant_types

--- a/oauth2_provider/validators.py
+++ b/oauth2_provider/validators.py
@@ -24,6 +24,11 @@ class RedirectURIValidator(URIValidator):
         self.allow_fragments = allow_fragments
 
     def __call__(self, value):
+        # Accept oob values without doing further checks since they don't conform
+        # to URI standards.
+        if value in ["urn:ietf:wg:oauth:2.0:oob", "urn:ietf:wg:oauth:2.0:oob:auto"]:
+            return
+
         super().__call__(value)
         value = force_str(value)
         scheme, netloc, path, query, fragment = urlsplit(value)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -22,6 +22,17 @@ class TestValidators(TestCase):
             # Check ValidationError not thrown
             validator(uri)
 
+    def test_validate_oob_uris(self):
+        # oob is allowed regardless of scheme for backwards compatibility
+        validator = RedirectURIValidator(allowed_schemes=["https"])
+        good_uris = [
+            "urn:ietf:wg:oauth:2.0:oob",
+            "urn:ietf:wg:oauth:2.0:oob:auto",
+        ]
+        for uri in good_uris:
+            # Check ValidationError not thrown
+            validator(uri)
+
     def test_validate_custom_uri_scheme(self):
         validator = RedirectURIValidator(allowed_schemes=["my-scheme", "https", "git+ssh"])
         good_uris = [


### PR DESCRIPTION
This addresses [this comment](https://github.com/jazzband/django-oauth-toolkit/issues/971#issuecomment-1016139005) made in #971.

## Description of the Change

The out of band (oob) protocol is supported within django-oauth-toolkit but paradoxically can't be configured using the forms, either in the Django admin or in the views provided. The tests test oob by creating an Application at the model layer, bypassing the typical validation. Because the allowed oob values don't look like a URI, they had to be shoehorned into the URI validator with a short circuit return, and `urn` had to be added as an "always valid" scheme.

This is a little bit hackier than I'd like, however oob is still widely used and solves a valuable niche in OAuth (CLI applications). This was the least hacky patch I could come up with to maintain backwards compatibility.

## Checklist

- [X] PR only contains one change (considered splitting up PR)
- [X] unit-test added
- [ ] documentation updated
- [X] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
