### PR TITLE
OIDC: Add "scopes_supported" to openid-configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.0] unreleased
 
 ### Added
-* #1106 Add "scopes_supported" to the [ConnectDiscoveryInfoView](https://django-oauth-toolkit.readthedocs.io/en/latest/oidc.html#connectdiscoveryinfoview)
+* #1106 Add "scopes_supported" to the [ConnectDiscoveryInfoView](https://django-oauth-toolkit.readthedocs.io/en/latest/oidc.html#connectdiscoveryinfoview).
+  This completes the view to provide all the REQUIRED and RECOMMENDED [OpenID Provider Metadata](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata).
 
 ### Changed
 * #1093 (**Breaking**) Changed to implement [hashed](https://docs.djangoproject.com/en/stable/topics/auth/passwords/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] unreleased
 
+### Added
+* #1106 Add "scopes_supported" to the [ConnectDiscoveryInfoView](https://django-oauth-toolkit.readthedocs.io/en/latest/oidc.html#connectdiscoveryinfoview)
+
 ### Changed
 * #1093 (**Breaking**) Changed to implement [hashed](https://docs.djangoproject.com/en/stable/topics/auth/passwords/)
   client_secret values. This is a **breaking change** that will migrate all your existing

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -18,7 +18,8 @@ Application = get_application_model()
 
 class ConnectDiscoveryInfoView(OIDCOnlyMixin, View):
     """
-    View used to show oidc provider configuration information
+    View used to show oidc provider configuration information per
+    `OpenID Provider Metadata <https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata>`_
     """
 
     def get(self, request, *args, **kwargs):
@@ -49,6 +50,9 @@ class ConnectDiscoveryInfoView(OIDCOnlyMixin, View):
         validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
         validator = validator_class()
         oidc_claims = list(set(validator.get_discovery_claims(request)))
+        scopes_class = oauth2_settings.SCOPES_BACKEND_CLASS
+        scopes = scopes_class()
+        scopes_supported = [scope for scope in scopes.get_available_scopes()]
 
         data = {
             "issuer": issuer_url,
@@ -56,6 +60,7 @@ class ConnectDiscoveryInfoView(OIDCOnlyMixin, View):
             "token_endpoint": token_endpoint,
             "userinfo_endpoint": userinfo_endpoint,
             "jwks_uri": jwks_uri,
+            "scopes_supported": scopes_supported,
             "response_types_supported": oauth2_settings.OIDC_RESPONSE_TYPES_SUPPORTED,
             "subject_types_supported": oauth2_settings.OIDC_SUBJECT_TYPES_SUPPORTED,
             "id_token_signing_alg_values_supported": signing_algorithms,

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -17,6 +17,7 @@ class TestConnectDiscoveryInfoView(TestCase):
             "token_endpoint": "http://localhost/o/token/",
             "userinfo_endpoint": "http://localhost/o/userinfo/",
             "jwks_uri": "http://localhost/o/.well-known/jwks.json",
+            "scopes_supported": ["read", "write", "openid"],
             "response_types_supported": [
                 "code",
                 "token",
@@ -44,6 +45,7 @@ class TestConnectDiscoveryInfoView(TestCase):
             "token_endpoint": "http://testserver/o/token/",
             "userinfo_endpoint": "http://testserver/o/userinfo/",
             "jwks_uri": "http://testserver/o/.well-known/jwks.json",
+            "scopes_supported": ["read", "write", "openid"],
             "response_types_supported": [
                 "code",
                 "token",


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #

## Description of the Change
Adds "scopes_supported" to openid-configuration metadata response.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
