### PR TITLE
Serve discovery view on both routes

### DIFF
--- a/oauth2_provider/urls.py
+++ b/oauth2_provider/urls.py
@@ -32,7 +32,7 @@ management_urlpatterns = [
 
 oidc_urlpatterns = [
     re_path(
-        r"^\.well-known/openid-configuration/$",
+        r"^\.well-known/openid-configuration/?$",
         views.ConnectDiscoveryInfoView.as_view(),
         name="oidc-connect-discovery-info",
     ),


### PR DESCRIPTION
Serving the discovery view on both routes enables usage of third-party clients, which only request the view without a trailing slash and doesn't follow a 301 redirect.

<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1089

## Description of the Change

Making the trailing slash optional allows serving the ConnectDiscoveryInfoView on both routes. The oidc guideline doesn't specify if 301 redirects should be followed and the default route to access a discovery info is without the trailing slash. Since Django defaults to redirecting all routes returning a 404 to its corresponding route with an appended slash (typically for a folder) one can circumstance this behavior by responding to the specific route.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
