### PR TITLE
Prevent the tests/migrations directory from getting packaged

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,6 +21,7 @@ Ash Christopher
 Asif Saif Uddin
 Bart Merenda
 Bas van Oostveen
+Brian Helba
 Dave Burkholder
 David Fischer
 David Smith

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,4 +38,6 @@ install_requires =
 	jwcrypto >= 0.8.0
 
 [options.packages.find]
-exclude = tests
+exclude =
+	tests
+	tests.*


### PR DESCRIPTION
Simply excluding `tests` is not enough to prevent subpackages from also being excluded. If a wildcard is provided to `find_packages(exclude=`, it will only match a single hierarchy level.

Without this, a directory `site-packages/tests/migrations` gets created upon package install.

## Checklist
- [x] PR only contains one change (considered splitting up PR)
- [ ] ~unit-test added~
- [ ] ~documentation updated~
- [ ] ~`CHANGELOG.md` updated (only for user relevant changes)~
- [x] author name in `AUTHORS`
