### PR TITLE
Fix broken import in doc

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,6 +22,7 @@ Asif Saif Uddin
 Bart Merenda
 Bas van Oostveen
 Brian Helba
+Carl Schwan
 Dave Burkholder
 David Fischer
 David Smith

--- a/docs/oidc.rst
+++ b/docs/oidc.rst
@@ -80,7 +80,7 @@ Now we need to add this key to our settings and allow the ``openid`` scope to
 be used. Assuming we have set an environment variable called
 ``OIDC_RSA_PRIVATE_KEY``, we can make changes to our ``settings.py``::
 
-    import os.environ
+    import os
 
     OAUTH2_PROVIDER = {
         "OIDC_ENABLED": True,


### PR DESCRIPTION
## Description of the Change

`inport os.environ` is incorrect since environ is not a module,  instead we just need to do `import os` and use `os.environ`

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added (not needed, no new code)
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS` (not sure if this is needed, that change is not copyrightable because it's too trivial)
