### PR TITLE
fix(tasks): fix error caused by relative import

### DIFF
--- a/oauth2_provider/tasks.py
+++ b/oauth2_provider/tasks.py
@@ -3,6 +3,6 @@ from celery import shared_task
 
 @shared_task
 def clear_tokens():
-    from ...models import clear_expired  # noqa
+    from oauth2_provider.models import clear_expired
 
     clear_expired()


### PR DESCRIPTION
## Description of the Change

Running `oauth2_provider.tasks.clear_tokens` results in an error e.g.:
```python
>>> from oauth2_provider.tasks import clear_tokens
>>> clear_tokens()
Traceback (most recent call last):
  File "[python3.9]/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "[site-packages]/celery/local.py", line 188, in __call__
    return self._get_current_object()(*a, **kw)
  File "[site-packages]/celery/app/task.py", line 392, in __call__
    return self.run(*args, **kwargs)
  File "[site-packages]/oauth2_provider/tasks.py", line 6, in clear_tokens
    from ...models import clear_expired  # noqa
ImportError: attempted relative import beyond top-level package
```

This update fixes the import path.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
