### PR TITLE
Revert 1070 (Celery tasks.py)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252) "OAuth 2.0 for Native Apps" BCP. Google has
   [deprecated use of oob](https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html?m=1#disallowed-oob) with
   a final end date of 2022-10-03. If you still rely on oob support in django-oauth-toolkit, do not upgrade to this release.
+* #1126 Reverts #1070 which incorrectly added Celery auto-discovery tasks.py (as described in #1123) and because it conflicts
+  with Huey's auto-discovery which also uses tasks.py as described in #1114. If you are using Celery or Huey, you'll need
+  to separately implement these tasks.
 
 ## [1.7.0] 2022-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252) "OAuth 2.0 for Native Apps" BCP. Google has
   [deprecated use of oob](https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html?m=1#disallowed-oob) with
   a final end date of 2022-10-03. If you still rely on oob support in django-oauth-toolkit, do not upgrade to this release.
+
+## [1.7.1] 2022-03-19
+
+### Removed
 * #1126 Reverts #1070 which incorrectly added Celery auto-discovery tasks.py (as described in #1123) and because it conflicts
   with Huey's auto-discovery which also uses tasks.py as described in #1114. If you are using Celery or Huey, you'll need
   to separately implement these tasks.

--- a/docs/management_commands.rst
+++ b/docs/management_commands.rst
@@ -21,8 +21,3 @@ To prevent the CPU and RAM high peaks during deletion process use ``CLEAR_EXPIRE
 
 Note: Refresh tokens need to expire before AccessTokens can be removed from the
 database. Using ``cleartokens`` without ``REFRESH_TOKEN_EXPIRE_SECONDS`` has limited effect.
-
-The ``cleartokens`` action can also be scheduled as a `Celery periodic task`_
-by using the ``clear_tokens`` task (automatically registered when using Celery).
-
-.. _Celery periodic task: https://docs.celeryproject.org/en/stable/userguide/periodic-tasks.html

--- a/oauth2_provider/tasks.py
+++ b/oauth2_provider/tasks.py
@@ -1,8 +1,0 @@
-from celery import shared_task
-
-
-@shared_task
-def clear_tokens():
-    from ...models import clear_expired  # noqa
-
-    clear_expired()


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1114 
Fixes #1123

## Description of the Change

#1070 was apparently not tested (and was not supplied with a test case). It could never have worked and also has since been flagged as conflicting with Huey's auto-discovery which also uses `tasks.py`.

A future PR _might_ come which will document how to configure a Celery `clear_tokens` task.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
