### PR TITLE
Update `createapplication` command

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Bart Merenda
 Bas van Oostveen
 Brian Helba
 Carl Schwan
+Daniel 'Vector' Kerr
 Dave Burkholder
 David Fischer
 David Smith

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   If you've [customized OIDC responses](https://django-oauth-toolkit.readthedocs.io/en/latest/oidc.html#customizing-the-oidc-responses)
   and want to retain the pre-2.x behavior, set `oidc_claim_scope = None` in your subclass of `OAuth2Validator`.
 * #1108 OIDC: Make the `access_token` available to `get_oidc_claims` when called from `get_userinfo_claims`.
+* Added `--algorithm` argument to `createapplication` management command
 
 ### Fixed
 * #1108 OIDC: Fix `validate_bearer_token()` to properly set `request.scopes` to the list of granted scopes.
+* Fixed help text for `--skip-authorization` argument of the `createapplication` management command
 
 ### Removed
 * #1124 (**Breaking**, **Security**) Removes support for insecure `urn:ietf:wg:oauth:2.0:oob` and `urn:ietf:wg:oauth:2.0:oob:auto` which are replaced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   If you've [customized OIDC responses](https://django-oauth-toolkit.readthedocs.io/en/latest/oidc.html#customizing-the-oidc-responses)
   and want to retain the pre-2.x behavior, set `oidc_claim_scope = None` in your subclass of `OAuth2Validator`.
 * #1108 OIDC: Make the `access_token` available to `get_oidc_claims` when called from `get_userinfo_claims`.
-* Added `--algorithm` argument to `createapplication` management command
+* #1132: Added `--algorithm` argument to `createapplication` management command
 
 ### Fixed
 * #1108 OIDC: Fix `validate_bearer_token()` to properly set `request.scopes` to the list of granted scopes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * #1108 OIDC: Fix `validate_bearer_token()` to properly set `request.scopes` to the list of granted scopes.
-* Fixed help text for `--skip-authorization` argument of the `createapplication` management command
+* #1132: Fixed help text for `--skip-authorization` argument of the `createapplication` management command
 
 ### Removed
 * #1124 (**Breaking**, **Security**) Removes support for insecure `urn:ietf:wg:oauth:2.0:oob` and `urn:ietf:wg:oauth:2.0:oob:auto` which are replaced

--- a/docs/management_commands.rst
+++ b/docs/management_commands.rst
@@ -4,6 +4,8 @@ Management commands
 Django OAuth Toolkit exposes some useful management commands that can be run via shell or by other means (eg: cron)
 
 .. _cleartokens:
+.. _createapplication:
+
 
 cleartokens
 ~~~~~~~~~~~
@@ -21,3 +23,39 @@ To prevent the CPU and RAM high peaks during deletion process use ``CLEAR_EXPIRE
 
 Note: Refresh tokens need to expire before AccessTokens can be removed from the
 database. Using ``cleartokens`` without ``REFRESH_TOKEN_EXPIRE_SECONDS`` has limited effect.
+
+
+
+createapplication
+~~~~~~~~~~~~~~~~~
+
+The ``createapplication`` management command provides a shortcut to create a new application in a programmatic way.
+
+This command is used like this:
+
+.. code-block:: sh
+    
+    python3 manage.py createapplication [arguments] <client_type> <authorization_grant_type>
+
+
+This command provides the following arguments:
+
++----------------------------+------+-------------------------------------------------------------------------------------------------+
+|          Argument          | type |                                           Description                                           |
++============================+======+=================================================================================================+
+| `--client_id`              | str  | The ID of the new application                                                                   |
++----------------------------+------+-------------------------------------------------------------------------------------------------+
+| `--user`                   | int  | The ID of the user that the application belongs to                                              |
++----------------------------+------+-------------------------------------------------------------------------------------------------+
+| `--redirect-uris`          | str  | The redirect URIs. This must be a space-separated string (e.g., `"https://uri1/ https://uri2"`) |
++----------------------------+------+-------------------------------------------------------------------------------------------------+
+| `--name`                   | str  | The name of this application                                                                    |
++----------------------------+------+-------------------------------------------------------------------------------------------------+
+| `--skip-authorization`     | flag | If set, completely bypass the authorization form, even on the first use of the application      |
++----------------------------+------+-------------------------------------------------------------------------------------------------+
+| `--algorithm`              | str  | The OIDC token signing algorithm for this application (e.g., `RS256` or `HS256`)                |
++----------------------------+------+-------------------------------------------------------------------------------------------------+
+| `client_type`              | str  | The client type, can be `confidential` or `public`                                              |
++----------------------------+------+-------------------------------------------------------------------------------------------------+
+| `authorization_grant_type` | str  | The type of authorization grant to be used                                                      |
++----------------------------+------+-------------------------------------------------------------------------------------------------+

--- a/docs/management_commands.rst
+++ b/docs/management_commands.rst
@@ -31,35 +31,30 @@ createapplication
 
 The ``createapplication`` management command provides a shortcut to create a new application in a programmatic way.
 
-This command is used like this:
-
 .. code-block:: sh
 
-    python3 manage.py createapplication [arguments] <client_type> <authorization_grant_type>
+    usage: manage.py createapplication [-h] [--client-id CLIENT_ID] [--user USER] [--redirect-uris REDIRECT_URIS]
+				       [--client-secret CLIENT_SECRET] [--name NAME] [--skip-authorization] [--version] [-v {0,1,2,3}]
+				       [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color]
+				       [--skip-checks]
+				       client_type authorization_grant_type
 
+    Shortcut to create a new application in a programmatic way
 
-usage: manage.py createapplication [-h] [--client-id CLIENT_ID] [--user USER] [--redirect-uris REDIRECT_URIS]
-                                   [--client-secret CLIENT_SECRET] [--name NAME] [--skip-authorization] [--version] [-v {0,1,2,3}]
-                                   [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color]
-                                   [--skip-checks]
-                                   client_type authorization_grant_type
+    positional arguments:
+      client_type           The client type, can be confidential or public
+      authorization_grant_type
+			    The type of authorization grant to be used
 
-Shortcut to create a new application in a programmatic way
-
-positional arguments:
-  client_type           The client type, can be confidential or public
-  authorization_grant_type
-                        The type of authorization grant to be used
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --client-id CLIENT_ID
-                        The ID of the new application
-  --user USER           The user the application belongs to
-  --redirect-uris REDIRECT_URIS
-                        The redirect URIs, this must be a space separated string e.g 'URI1 URI2'
-  --client-secret CLIENT_SECRET
-                        The secret for this application
-  --name NAME           The name this application
-  --skip-authorization  The ID of the new application
-  ...
+    optional arguments:
+      -h, --help            show this help message and exit
+      --client-id CLIENT_ID
+			    The ID of the new application
+      --user USER           The user the application belongs to
+      --redirect-uris REDIRECT_URIS
+			    The redirect URIs, this must be a space separated string e.g 'URI1 URI2'
+      --client-secret CLIENT_SECRET
+			    The secret for this application
+      --name NAME           The name this application
+      --skip-authorization  The ID of the new application
+      ...

--- a/docs/management_commands.rst
+++ b/docs/management_commands.rst
@@ -38,24 +38,28 @@ This command is used like this:
     python3 manage.py createapplication [arguments] <client_type> <authorization_grant_type>
 
 
-This command provides the following arguments:
+usage: manage.py createapplication [-h] [--client-id CLIENT_ID] [--user USER] [--redirect-uris REDIRECT_URIS]
+                                   [--client-secret CLIENT_SECRET] [--name NAME] [--skip-authorization] [--version] [-v {0,1,2,3}]
+                                   [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color]
+                                   [--skip-checks]
+                                   client_type authorization_grant_type
 
-+----------------------------+------+-------------------------------------------------------------------------------------------------+
-|          Argument          | type |                                           Description                                           |
-+============================+======+=================================================================================================+
-| `--client_id`              | str  | The ID of the new application                                                                   |
-+----------------------------+------+-------------------------------------------------------------------------------------------------+
-| `--user`                   | int  | The ID of the user that the application belongs to                                              |
-+----------------------------+------+-------------------------------------------------------------------------------------------------+
-| `--redirect-uris`          | str  | The redirect URIs. This must be a space-separated string (e.g., `"https://uri1/ https://uri2"`) |
-+----------------------------+------+-------------------------------------------------------------------------------------------------+
-| `--name`                   | str  | The name of this application                                                                    |
-+----------------------------+------+-------------------------------------------------------------------------------------------------+
-| `--skip-authorization`     | flag | If set, completely bypass the authorization form, even on the first use of the application      |
-+----------------------------+------+-------------------------------------------------------------------------------------------------+
-| `--algorithm`              | str  | The OIDC token signing algorithm for this application (e.g., `RS256` or `HS256`)                |
-+----------------------------+------+-------------------------------------------------------------------------------------------------+
-| `client_type`              | str  | The client type, can be `confidential` or `public`                                              |
-+----------------------------+------+-------------------------------------------------------------------------------------------------+
-| `authorization_grant_type` | str  | The type of authorization grant to be used                                                      |
-+----------------------------+------+-------------------------------------------------------------------------------------------------+
+Shortcut to create a new application in a programmatic way
+
+positional arguments:
+  client_type           The client type, can be confidential or public
+  authorization_grant_type
+                        The type of authorization grant to be used
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --client-id CLIENT_ID
+                        The ID of the new application
+  --user USER           The user the application belongs to
+  --redirect-uris REDIRECT_URIS
+                        The redirect URIs, this must be a space separated string e.g 'URI1 URI2'
+  --client-secret CLIENT_SECRET
+                        The secret for this application
+  --name NAME           The name this application
+  --skip-authorization  The ID of the new application
+  ...

--- a/docs/management_commands.rst
+++ b/docs/management_commands.rst
@@ -34,7 +34,7 @@ The ``createapplication`` management command provides a shortcut to create a new
 This command is used like this:
 
 .. code-block:: sh
-    
+
     python3 manage.py createapplication [arguments] <client_type> <authorization_grant_type>
 
 

--- a/oauth2_provider/management/commands/createapplication.py
+++ b/oauth2_provider/management/commands/createapplication.py
@@ -54,9 +54,9 @@ class Command(BaseCommand):
         parser.add_argument(
             "--algorithm",
             type=str,
-            help="The OIDC token signing algorithm for this application (e.g., 'RS256' or 'HS256')"
+            help="The OIDC token signing algorithm for this application (e.g., 'RS256' or 'HS256')",
         )
-    
+
     def handle(self, *args, **options):
         # Extract all fields related to the application, this will work now and in the future
         # and also with custom application models.

--- a/oauth2_provider/management/commands/createapplication.py
+++ b/oauth2_provider/management/commands/createapplication.py
@@ -49,9 +49,14 @@ class Command(BaseCommand):
         parser.add_argument(
             "--skip-authorization",
             action="store_true",
-            help="The ID of the new application",
+            help="If set, completely bypass the authorization form, even on the first use of the application",
         )
-
+        parser.add_argument(
+            "--algorithm",
+            type=str,
+            help="The OIDC token signing algorithm for this application (e.g., 'RS256' or 'HS256')"
+        )
+    
     def handle(self, *args, **options):
         # Extract all fields related to the application, this will work now and in the future
         # and also with custom application models.

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,5 +1,6 @@
 from io import StringIO
 
+import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import check_password
 from django.core.management import call_command
@@ -8,6 +9,7 @@ from django.test import TestCase
 
 from oauth2_provider.models import get_application_model
 
+from . import presets
 
 Application = get_application_model()
 
@@ -111,6 +113,20 @@ class CreateApplicationTest(TestCase):
         app = Application.objects.get()
 
         self.assertEqual(app.user, user)
+
+    @pytest.mark.usefixtures("oauth2_settings")
+    @pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)
+    def test_application_created_with_algorithm(self):
+        call_command(
+            "createapplication",
+            "confidential",
+            "authorization-code",
+            "--redirect-uris=http://example.com http://example2.com",
+            "--algorithm=RS256",
+        )
+        app = Application.objects.get()
+
+        self.assertEqual(app.algorithm, "RS256")
 
     def test_validation_failed_message(self):
         output = StringIO()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -11,6 +11,7 @@ from oauth2_provider.models import get_application_model
 
 from . import presets
 
+
 Application = get_application_model()
 
 


### PR DESCRIPTION
Fixes #
N/A

## Description of the Change

Greetings!

This pull request updates the createapplication management command.

* The `--algorighm` parameter is added which allows specification of `""`, `"RS256"`, or `"HS256"`
* The `--skip-authorization` help text is fixed
    * It was previously incorrectly described as `"The ID of the new application"`
    * It is now described as `"If set, completely bypass the authorization form, even on the first use of the application"`

Notes:
* Documentation not updated because:
    * the command does not appear to be included in documentation
    * the command is self-documented (arguments and help strings displayed on invocation)

I hope you find this change useful!
\- Daniel.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
