### PR TITLE
Corrections to resource server documentation

### DIFF
--- a/docs/resource_server.rst
+++ b/docs/resource_server.rst
@@ -1,6 +1,6 @@
 Separate Resource Server
 ========================
-Django OAuth Toolkit allows to separate the :term:`Authentication Server` and the :term:`Resource Server.`
+Django OAuth Toolkit allows to separate the :term:`Authorization Server` and the :term:`Resource Server`.
 Based on the `RFC 7662 <https://tools.ietf.org/html/rfc7662>`_ Django OAuth Toolkit provides
 a rfc-compliant introspection endpoint.
 As well the Django OAuth Toolkit allows to verify access tokens by the use of an introspection endpoint.
@@ -8,7 +8,7 @@ As well the Django OAuth Toolkit allows to verify access tokens by the use of an
 
 Setup the Authentication Server
 -------------------------------
-Setup the :term:`Authentication Server` as described in the :ref:`tutorial`.
+Setup the :term:`Authorization Server` as described in the :doc:`tutorial/tutorial`.
 Create a OAuth2 access token for the :term:`Resource Server` and add the
 ``introspection``-Scope to the settings.
 
@@ -21,7 +21,7 @@ Create a OAuth2 access token for the :term:`Resource Server` and add the
         ...
     },
 
-The :term:`Authentication Server` will listen for introspection requests.
+The :term:`Authorization Server` will listen for introspection requests.
 The endpoint is located within the ``oauth2_provider.urls`` as ``/introspect/``.
 
 Example Request::
@@ -49,10 +49,10 @@ Example Response::
 
 Setup the Resource Server
 -------------------------
-Setup the :term:`Resource Server` like the :term:`Authentication Server` as described in the :ref:`tutorial`.
+Setup the :term:`Resource Server` like the :term:`Authorization Server` as described in the :doc:`tutorial/tutorial`.
 Add ``RESOURCE_SERVER_INTROSPECTION_URL`` and **either** ``RESOURCE_SERVER_AUTH_TOKEN``
 **or** ``RESOURCE_SERVER_INTROSPECTION_CREDENTIALS`` as a ``(id,secret)`` tuple to your settings.
-The :term:`Resource Server` will try to verify its requests on the :term:`Authentication Server`.
+The :term:`Resource Server` will try to verify its requests on the :term:`Authorization Server`.
 
 .. code-block:: python
 
@@ -66,7 +66,7 @@ The :term:`Resource Server` will try to verify its requests on the :term:`Authen
 
 ``RESOURCE_SERVER_INTROSPECTION_URL`` defines the introspection endpoint and
 ``RESOURCE_SERVER_AUTH_TOKEN`` an authentication token to authenticate against the
-:term:`Authentication Server`.
+:term:`Authorization Server`.
 As allowed by RFC 7662, some external OAuth 2.0 servers support HTTP Basic Authentication.
 For these, use:
 ``RESOURCE_SERVER_INTROSPECTION_CREDENTIALS=('client_id','client_secret')`` instead


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->

## Description of the Change
Corrects missing links to glossary and documentation:

- Authentication Server -> Authorization Server
- tutorial doc reference

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
