### PR TITLE
Add LOGIN_URL settings in getting_started.rst

### DIFF
--- a/docs/rest-framework/getting_started.rst
+++ b/docs/rest-framework/getting_started.rst
@@ -112,6 +112,8 @@ Also add the following to your `settings.py` module:
         )
     }
 
+    LOGIN_URL = '/admin/login/'
+
 `OAUTH2_PROVIDER.SCOPES` setting parameter contains the scopes that the application will be aware of,
 so we can use them for permission check.
 


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #

## Description of the Change
Added `LOGIN_URL = '/admin/login/'` to the `settings.py` in DOT tutorial for Django REST Framework. Without this, hitting `http://localhost:8000/o/applications/` redirects to URL not found error page.
## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ ] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
