### PR TITLE
Support prompt login

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Hossein Shakiba
 Hiroki Kiyohara
 Jens Timmerman
 Jerome Leclanche
+Jesse Gibbs
 Jim Graham
 Jonas Nygaard Pedersen
 Jonathan Steffan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+* Support `prompt=login` for the OIDC Authorization Code Flow end user [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
+
 ### Changed
 * #1152 `createapplication` management command enhanced to display an auto-generated secret before it gets hashed.
 

--- a/docs/oidc.rst
+++ b/docs/oidc.rst
@@ -359,6 +359,15 @@ token, so you will probably want to re-use that::
             claims["color_scheme"] = get_color_scheme(request.user)
             return claims
 
+Customizing the login flow
+==========================
+
+Clients can request that the user logs in each time a request to the
+``/authorize`` endpoint is made during the OIDC Authorization Code Flow by
+adding the ``prompt=login`` query parameter and value. Only ``login`` is
+currently supported. See
+OIDC's `3.1.2.1 Authentication Request <https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest>`_
+for details.
 
 OIDC Views
 ==========


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Hi team, thanks for the great library!

## Description of the Change
Adds support for `prompt=login` to comply with https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
