### PR TITLE
fixed typo which caused incorrect display of code block

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -256,7 +256,7 @@ Export ``Client id`` and ``Client secret`` values as environment variable:
     export ID=vW1RcAl7Mb0d5gyHNQIAcH110lWoOW2BmWJIero8
     export SECRET=DZFpuNjRdt5xUEzxXovAp40bU3lQvoMvF3awEStn61RXWE0Ses4RgzHWKJKTvUCHfRkhcBi3ebsEfSjfEO96vo2Sh6pZlxJ6f7KcUbhvqMMPoVxRwv4vfdWEoWMGPeIO
 
-Now let's generate an authentication code grant with PKCE (Proof Key for Code Exchange), useful to prevent authorization code injection. To do so, you must first generate a ``code_verifier`` random string between 43 and 128 characters, which is then encoded to produce a ``code_challenge``::
+Now let's generate an authentication code grant with PKCE (Proof Key for Code Exchange), useful to prevent authorization code injection. To do so, you must first generate a ``code_verifier`` random string between 43 and 128 characters, which is then encoded to produce a ``code_challenge``:
 
 .. sourcecode:: python
 


### PR DESCRIPTION
## Description of the Change
Fixed a typo in documentation which was causing the viewer to misbehave for .rst file.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
