### PR TITLE
Add required_scopes view decorator for function-based views

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -79,3 +79,4 @@ Dominik George
 David Hill
 Darrel O'Pry
 Jordi Sanchez
+Jay Turner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support `prompt=login` for the OIDC Authorization Code Flow end user [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
 * #1163 Adds French translations.
 * #1166 Add spanish (es) translations.
+* #1173 Add required_scopes decorator for DRF-function based views with TokenHasScope-based permission classes.
 
 ### Changed
 * #1152 `createapplication` management command enhanced to display an auto-generated secret before it gets hashed.

--- a/docs/rest-framework/permissions.rst
+++ b/docs/rest-framework/permissions.rst
@@ -23,7 +23,7 @@ For example:
         permission_classes = [TokenHasScope]
         required_scopes = ['music']
 
-The `required_scopes` attribute is mandatory.
+The `required_scopes` attribute is mandatory. There is a decorator for this at `oauth2_provider.contrib.rest_framework.decorators.required_scopes`.
 
 
 TokenHasReadWriteScope

--- a/docs/views/function_based.rst
+++ b/docs/views/function_based.rst
@@ -63,3 +63,17 @@ Django OAuth Toolkit provides decorators to help you in protecting your function
             # If this is a POST, you have to provide 'exotic_scope write' scopes to get here...
             # ...
             pass
+
+
+.. function:: required_scopes(required_scopes)(required_scopes(required_scopes))
+
+    Decorator to protect DRF function-based views for use with the TokenHasScope permission class::
+
+        from oauth2_provider.contrib.rest_framework.decorators import required_scopes
+
+        @api_view(["GET"])
+        @authentication_classes([OAuth2Authentication])
+        @permission_classes([TokenHasScope])
+        @required_scopes(["read"])
+        def my_view(request):
+            pass

--- a/docs/views/function_based.rst
+++ b/docs/views/function_based.rst
@@ -77,7 +77,7 @@ Django OAuth Toolkit provides decorators to help you in protecting your function
             permission_classes,
         )
 
-        
+
         @api_view(["GET"])
         @authentication_classes([OAuth2Authentication])
         @permission_classes([TokenHasScope])

--- a/docs/views/function_based.rst
+++ b/docs/views/function_based.rst
@@ -65,12 +65,19 @@ Django OAuth Toolkit provides decorators to help you in protecting your function
             pass
 
 
-.. function:: required_scopes(required_scopes)(required_scopes(required_scopes))
+.. function:: required_scopes(required_scopes)
 
     Decorator to protect DRF function-based views for use with the TokenHasScope permission class::
 
+        from oauth2_provider.contrib.rest_framework import OAuth2Authentication, TokenHasScope
         from oauth2_provider.contrib.rest_framework.decorators import required_scopes
+        from rest_framework.decorators import (
+            api_view,
+            authentication_classes,
+            permission_classes,
+        )
 
+        
         @api_view(["GET"])
         @authentication_classes([OAuth2Authentication])
         @permission_classes([TokenHasScope])

--- a/oauth2_provider/contrib/rest_framework/__init__.py
+++ b/oauth2_provider/contrib/rest_framework/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from .authentication import OAuth2Authentication
+from .decorators import required_scopes
 from .permissions import (
     IsAuthenticatedOrTokenHasScope,
     TokenHasReadWriteScope,

--- a/oauth2_provider/contrib/rest_framework/decorators.py
+++ b/oauth2_provider/contrib/rest_framework/decorators.py
@@ -1,0 +1,6 @@
+def required_scopes(required_scopes):
+    def decorator(func):
+        func.required_scopes = required_scopes
+        return func
+
+    return decorator


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->

## Description of the Change

Adds a decorator for adding the required_scopes parameter to function-based views for permission classes such as [TokenHasScope](https://github.com/jazzband/django-oauth-toolkit/blob/40b0de1df9000136e4a3ee8c81c027aca0b9def5/oauth2_provider/contrib/rest_framework/permissions.py#L14)

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
