### PR TITLE
Added list_select_related to reduce duplicate SQL queries in admin UI

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -79,3 +79,4 @@ Dominik George
 David Hill
 Darrel O'Pry
 Jordi Sanchez
+Owen Gong

--- a/oauth2_provider/admin.py
+++ b/oauth2_provider/admin.py
@@ -48,6 +48,7 @@ class IDTokenAdmin(admin.ModelAdmin):
     raw_id_fields = ("user",)
     search_fields = ("user__email",) if has_email else ()
     list_filter = ("application",)
+    list_select_related = ("application", "user")
 
 
 class RefreshTokenAdmin(admin.ModelAdmin):


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->

## Description of the Change

Added `list_select_related` in the admin `IDTokenAdmin` to avoid duplicate SQL queries. 

Before adding the `list_select_related`, every 100 items in the `IDToken` 206 SQL queries is executed:

![image](https://user-images.githubusercontent.com/5711185/174845982-c03788e3-d9c0-40b3-b775-29c81b5a3101.png)

After adding the `list_select_related`, every 100 items in the `IDToken` list 6 SQL queries is executed:

![image](https://user-images.githubusercontent.com/5711185/174846106-b04eddb2-f458-4fe7-874d-b0b16e33be51.png)

The total page loading time is 7305 milliseconds and 698 milliseconds respectively in my computer. It expects to reduce 10x the time.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
