### PR TITLE
Add 'code_verifier' parameter to token request

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,6 +49,7 @@ Joseph Abrahams
 Jozef Knaperek
 Julien Palard
 Jun Zhou
+Kaleb Porter
 Kristian Rune Larsen
 Michael Howitz
 Paul Dekkers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   -->
 
 ## [unreleased]
+* Add 'code_verifier' parameter to token requests in documentation
 
 ## [2.1.0] 2022-06-19
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -305,7 +305,7 @@ Export it as an environment variable:
 
 Now that you have the user authorization is time to get an access token::
 
-    curl -X POST -H "Cache-Control: no-cache" -H "Content-Type: application/x-www-form-urlencoded" "http://127.0.0.1:8000/o/token/" -d "client_id=${ID}" -d "client_secret=${SECRET}" -d "code=${CODE}" -d "redirect_uri=http://127.0.0.1:8000/noexist/callback" -d "grant_type=authorization_code"
+    curl -X POST -H "Cache-Control: no-cache" -H "Content-Type: application/x-www-form-urlencoded" "http://127.0.0.1:8000/o/token/" -d "client_id=${ID}" -d "client_secret=${SECRET}" -d "code=${CODE}" -d "code_verifier=${CODE_VERIFIER}" -d "redirect_uri=http://127.0.0.1:8000/noexist/callback" -d "grant_type=authorization_code"
 
 To be more easy to visualize::
 
@@ -316,6 +316,7 @@ To be more easy to visualize::
         -d "client_id=${ID}" \
         -d "client_secret=${SECRET}" \
         -d "code=${CODE}" \
+        -d "code_verifier=${CODE_VERIFIER}" \
         -d "redirect_uri=http://127.0.0.1:8000/noexist/callback" \
         -d "grant_type=authorization_code"
 


### PR DESCRIPTION
Fixes #1178


## Description of the Change
The getting started tutorial excludes the 'code_verifier' when fetching the access token. This is causing confusion, example https://github.com/jazzband/django-oauth-toolkit/issues/1178

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
