### PR TITLE
fix: returning first url as default when multiple

### DIFF
--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -132,8 +132,8 @@ class AbstractApplication(models.Model):
         """
         if self.redirect_uris:
             uris = self.redirect_uris.split()
-            if len(uris) == 1:
-                return self.redirect_uris.split().pop(0)
+            if uris:
+                return uris[0]
             raise errors.MissingRedirectURIError()
 
         assert False, (


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #

## Description of the Change

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ ] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
