### PR TITLE
Add configuration of PKCE_REQUIRED for consumer service

### DIFF
--- a/docs/tutorial/tutorial_01.rst
+++ b/docs/tutorial/tutorial_01.rst
@@ -59,6 +59,14 @@ Allow CORS requests from all domains (just for the scope of this tutorial):
 
     CORS_ORIGIN_ALLOW_ALL = True
 
+Disable PKCE requirement for compatibility with the `consumer service <http://django-oauth-toolkit.herokuapp.com/consumer/>`_ deployed on Heroku.
+
+.. code-block:: python
+
+    OAUTH2_PROVIDER = {
+        'PKCE_REQUIRED': False,  # pre-2.x behaviour
+    }
+
 .. _loginTemplate:
 
 Include the required hidden input in your login template, `registration/login.html`.


### PR DESCRIPTION
## Description of the Change

The consumer service at [heroku](http://django-oauth-toolkit.herokuapp.com/consumer/) does not work as described in the tutorial with `PKCE_REQUIRED=True`. Since this is the default since 2.x the tutorial does not work anymore...

PR adds a note about disabling PKCE to the docs.


## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] documentation updated
