### PR TITLE
Fix tox env used for flake8 in contributing docs

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -263,7 +263,7 @@ Try reading our code and grasp the overall philosophy regarding method and varia
 the sake of readability, keep in mind that *simple is better than complex*. If you feel the code is not straightforward,
 add a comment. If you think a function is not trivial, add a docstrings.
 
-To see if your code formatting will pass muster use: `tox -e py37-flake8`
+To see if your code formatting will pass muster use: `tox -e flake8`
 
 
 The contents of this page are heavily based on the docs from `django-admin2 <https://github.com/twoscoops/django-admin2>`_


### PR DESCRIPTION
## Description of the Change

The tox environment to run flake8 changed in https://github.com/jazzband/django-oauth-toolkit/commit/6af081c8053dc9712cb4822f5c876d18269b7851.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] documentation updated
