### PR TITLE
Split Migration 0004 into two migrations

### DIFF
--- a/oauth2_provider/migrations/0004_auto_20200902_2022.py
+++ b/oauth2_provider/migrations/0004_auto_20200902_2022.py
@@ -45,6 +45,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='accesstoken',
             name='id_token',
+            field=models.IntegerField(),
+        ),
+        migrations.AlterField(
+            model_name='accesstoken',
+            name='id_token',
             field=models.OneToOneField(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='access_token', to=oauth2_settings.ID_TOKEN_MODEL),
         ),
         migrations.AddField(


### PR DESCRIPTION
Citus Postgres DB doesnt allow adding of new field with constrains on it.  Example Error attached

You can issue each command separately such as ALTER TABLE oauth2_provider_accesstoken ADD COLUMN id_token data_type; ALTER TABLE oauth2_provider_accesstoken ADD CONSTRAINT constraint_name CHECK (check_expression);

<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #

## Description of the Change

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
