### PR TITLE
Test Django 4.1 and remove upper version bound

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Contributors
 ------------
 
 Abhishek Patel
+Adam Johnson
 Alan Crosswell
 Alejandro Mantecon Guillen
 Aleksander Vaskevich

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 * Add 'code_verifier' parameter to token requests in documentation
+* Remove upper version bound on Django, to allow upgrading to Django 4.1.1 bugfix release.
 
 ## [2.1.0] 2022-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   -->
 
 ## [unreleased]
+
+### Added
 * Add 'code_verifier' parameter to token requests in documentation
+
+### Changed
 * Support Django 4.1.
+
+### Fixed
 * Remove upper version bound on Django, to allow upgrading to Django 4.1.1 bugfix release.
 
 ## [2.1.0] 2022-06-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 * Add 'code_verifier' parameter to token requests in documentation
+* Support Django 4.1.
 * Remove upper version bound on Django, to allow upgrading to Django 4.1.1 bugfix release.
 
 ## [2.1.0] 2022-06-19

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
 	Framework :: Django :: 2.2
 	Framework :: Django :: 3.2
 	Framework :: Django :: 4.0
+	Framework :: Django :: 4.1
 	Intended Audience :: Developers
 	License :: OSI Approved :: BSD License
 	Operating System :: OS Independent

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ zip_safe = False
 # jwcrypto has a direct dependency on six, but does not list it yet in a release
 # Previously, cryptography also depended on six, so this was unnoticed
 install_requires =
-	django >= 2.2, <= 4.1
+	django >= 2.2, != 4.0.0
 	requests >= 2.13.0
 	oauthlib >= 3.1.0
 	jwcrypto >= 0.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
     py{37,38,39}-dj22,
     py{37,38,39,310}-dj32,
     py{38,39,310}-dj40,
+    py{38,39,310}-dj41,
     py{38,39,310}-djmain,
 
 [gh-actions]
@@ -40,6 +41,7 @@ deps =
     dj22: Django>=2.2,<3
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0.0,<4.1
+    dj41: Django>=4.1,<4.2
     djmain: https://github.com/django/django/archive/main.tar.gz
     djangorestframework
     oauthlib>=3.1.0


### PR DESCRIPTION
Fixes #1202

## Description of the Change

Remove upper version bound, as I recommended on the ticket.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
