### PR TITLE
Hotfix- authorization_code_expire_seconds docs clarified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changed
+* #1211 documentation improvements.
+
 ### Added
 * Add 'code_challenge_method' parameter to authorization call in documentation
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -29,9 +29,12 @@ List of available settings
 
 ACCESS_TOKEN_EXPIRE_SECONDS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``36000``
+
 The number of seconds an access token remains valid. Requesting a protected
 resource after this duration will fail. Keep this value high enough so clients
-can cache the token for a reasonable amount of time. (default: 36000)
+can cache the token for a reasonable amount of time.
 
 ACCESS_TOKEN_MODEL
 ~~~~~~~~~~~~~~~~~~
@@ -69,9 +72,11 @@ this value if you wrote your own implementation (subclass of
 
 AUTHORIZATION_CODE_EXPIRE_SECONDS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Default: ``60``
+
 The number of seconds an authorization code remains valid. Requesting an access
-token after this duration will fail. :rfc:`4.1.2` recommends a
-10 minutes (600 seconds) duration.
+token after this duration will fail. :rfc:`4.1.2` recommends expire after a short lifetime,
+being 10 minutes (600 seconds) the maximum acceptable.
 
 CLIENT_ID_GENERATOR_CLASS
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -76,7 +76,7 @@ Default: ``60``
 
 The number of seconds an authorization code remains valid. Requesting an access
 token after this duration will fail. :rfc:`4.1.2` recommends expire after a short lifetime,
-being 10 minutes (600 seconds) the maximum acceptable.
+with 10 minutes (600 seconds) being the maximum acceptable.
 
 CLIENT_ID_GENERATOR_CLASS
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1211 

## Description of the Change
Fix confusing documentation about `AUTHORIZATION_CODE_EXPIRE_SECONDS`.
Matching `Default` `ACCESS_TOKEN_EXPIRE_SECONDS` like in the other settings in docs.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
