### PR TITLE
Parallelize CI workflow by adding Django versions to job matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
+    name: build (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         exclude:
           # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 
-          # Python > 3.9 is not supported by Django 2.2
+          # Python 3.10+ is not supported by Django 2.2
           - python-version: '3.10'
             django-version: '2.2'
           

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 5
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         django-version: ['2.2', '3.2', '4.0', '4.1', 'main']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,12 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        django-version: ['3.2', '4.0', '4.1', 'main']
+        exclude:
+          - python-version: '3.7'
+            django-version: '4.0'
+          - python-version: '3.7'
+            django-version: '4.1'
 
     steps:
     - uses: actions/checkout@v2
@@ -42,6 +48,8 @@ jobs:
     - name: Tox tests
       run: |
         tox -v
+      env:
+        DJANGO: ${{ matrix.django-version }}
 
     - name: Upload coverage
       uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           # Python 3.10+ is not supported by Django 2.2
           - python-version: '3.10'
             django-version: '2.2'
-          
+
           # Python 3.7 is not supported by Django 4.0+
           - python-version: '3.7'
             django-version: '4.0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,21 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        django-version: ['3.2', '4.0', '4.1', 'main']
+        django-version: ['2.2', '3.2', '4.0', '4.1', 'main']
         exclude:
+          # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
+
+          # Python > 3.9 is not supported by Django 2.2
+          - python-version: '3.10'
+            django-version: '2.2'
+          
+          # Python 3.7 is not supported by Django 4.0+
           - python-version: '3.7'
             django-version: '4.0'
           - python-version: '3.7'
             django-version: '4.1'
+          - python-version: '3.7'
+            django-version: 'main'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,3 +64,11 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         name: Python ${{ matrix.python-version }}
+
+  success:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Test successful
+    steps:
+      - name: Success
+        run: echo Test successful

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,15 @@ python =
     3.10: py310
     3.11: py311
 
+[gh-actions:env]
+DJANGO =
+    2.2: dj22
+    3.2: dj32
+    4.0: dj40
+    4.1: dj41
+    main: djmain
+
+
 [pytest]
 django_find_project = false
 addopts =

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,6 @@ DJANGO =
     4.1: dj41
     main: djmain
 
-
 [pytest]
 django_find_project = false
 addopts =


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
## Description of the Change
Adds an additional job matrix that includes all the Django versions this package supports and excludes certain combinations of Python and Django from running. Also removes the `max-parallel` restriction for parallel CI jobs.

This should dramatically speed up CI tests, cutting almost 20 minutes from the total runtime.

Note: I have another open PR (#1218) that adds Python 3.11 to CI and tox. Either this PR or that one will need to be rebased once either one is accepted and merged.

### Before

**~25 minutes**

![image](https://user-images.githubusercontent.com/19896267/198388156-99041159-b4b9-4973-92f8-441aa8616cdd.png)

### After

**~8 minutes**

![image](https://user-images.githubusercontent.com/19896267/198389042-0ecaba18-1348-42cc-903d-5544c55031f8.png)

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
