### PR TITLE
tox whitelist_externals deprecated and replaced with allowlist_externals

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ commands =
 [testenv:{docs,livedocs}]
 basepython = python3.8
 changedir = docs
-whitelist_externals = make
+allowlist_externals = make
 commands =
     docs: make html
     livedocs: make livehtml


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
## Description of the Change

Replaces deprecated tox.ini `whitelist_externals` with `allowlist_externals`.  This is breaking any new PR as of the tox version upgrade.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
