### PR TITLE
Remove incompatible python+django version combinations from CI

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ Joseph Abrahams
 Josh Thomas
 Jozef Knaperek
 Julien Palard
+Julian Mundhahs
 Jun Zhou
 Kaleb Porter
 Kristian Rune Larsen

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
     py{37,38,39,310}-dj32,
     py{38,39,310}-dj40,
     py{38,39,310,311}-dj41,
-    py{38,39,310,311}-djmain,
+    py{310,311}-djmain,
 
 [gh-actions]
 python =


### PR DESCRIPTION
## Description of the Change
The pipeline tests are failing for `djmain` with python < 3.10 because the main branch of django requires python >= 3.10. This PR removes the incompatible python versions from the `djmain` step.

### Why did the tests break?
Django has released 4.2 alpha 1[^1] with a feature freeze on 17/01/2023. This means that the main branch is now working towards 5.0 and has thus dropped python < 3.10[^2] on 18/01/2023.

[^1]: https://www.djangoproject.com/weblog/2023/jan/17/django-42-alpha-1-released/
[^2]: https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
