### PR TITLE
Format with new Black version 23.1.0

### DIFF
--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -749,7 +749,6 @@ def redirect_to_uri_allowed(uri, allowed_uris):
             and parsed_allowed_uri.netloc == parsed_uri.netloc
             and parsed_allowed_uri.path == parsed_uri.path
         ):
-
             aqs_set = set(parse_qsl(parsed_allowed_uri.query))
             if aqs_set.issubset(uqs_set):
                 return True

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -572,7 +572,6 @@ class OAuth2Validator(RequestValidator):
                 and isinstance(refresh_token_instance, RefreshToken)
                 and refresh_token_instance.access_token
             ):
-
                 access_token = AccessToken.objects.select_for_update().get(
                     pk=refresh_token_instance.access_token.pk
                 )

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -86,7 +86,6 @@ class JwksInfoView(OIDCOnlyMixin, View):
                 oauth2_settings.OIDC_RSA_PRIVATE_KEY,
                 *oauth2_settings.OIDC_RSA_PRIVATE_KEYS_INACTIVE,
             ]:
-
                 key = jwk.JWK.from_pem(pem.encode("utf8"))
                 data = {"alg": "RS256", "use": "sig", "kid": key.thumbprint()}
                 data.update(json.loads(key.export_public()))

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -160,7 +160,6 @@ class TestOAuth2Validator(TransactionTestCase):
             self.validator.save_bearer_token(token, mock.MagicMock())
 
     def test_save_bearer_token__with_existing_tokens__does_not_create_new_tokens(self):
-
         rotate_token_function = mock.MagicMock()
         rotate_token_function.return_value = False
         self.validator.rotate_refresh_token = rotate_token_function
@@ -190,7 +189,6 @@ class TestOAuth2Validator(TransactionTestCase):
         self.assertEqual(1, AccessToken.objects.count())
 
     def test_save_bearer_token__checks_to_rotate_tokens(self):
-
         rotate_token_function = mock.MagicMock()
         rotate_token_function.return_value = False
         self.validator.rotate_refresh_token = rotate_token_function


### PR DESCRIPTION
Apply [version 23.1.0 of Black](https://black.readthedocs.io/en/stable/change_log.html#id1) which comes with some changes to the codestyle.

## Description of the Change

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- n/a unit-test added
- n/a documentation updated
- n/a `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
