### PR TITLE
Fix documentation regarding rotate_refresh_token setting

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -177,7 +177,7 @@ this value if you wrote your own implementation (subclass of
 ROTATE_REFRESH_TOKEN
 ~~~~~~~~~~~~~~~~~~~~
 When is set to `True` (default) a new refresh token is issued to the client when the client refreshes an access token.
-Known bugs: `False` currently has a side effect of immediately revoking both access and refresh token on refreshing.
+If `False`, it will reuse the same refresh token and only update the access token with a new token value.
 See also: validator's rotate_refresh_token method can be overridden to make this variable
 (could be usable with expiring refresh tokens, in particular, so that they are rotated
 when close to expiration, theoretically).


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes [1240](https://github.com/jazzband/django-oauth-toolkit/issues/1240)

## Description of the Change
Removed 'known bug' from documentation due to it is not happening. 

The known bug states that when the `ROTATE_REFRESH_TOKEN` setting is set to `False`, was causing that both refresh token and access token get revoked

![image](https://user-images.githubusercontent.com/30764904/218279346-2c6a9c5a-609f-4b6e-a254-59f4a04da623.png)

For testing that this is working correctly I set the ROTATE_REFRESH_TOKEN to False in the `OAUTH2_PROVIDER` setting in `settings.py` file and then:

1. Created a password based application
2. Requested an access token using `password` as `grant_type`
3. Used the returned refresh token to run a new request but this time with `refresh_token` as `grant_type`

Tested that:

- The response included the **same** refresh_token in the response, and updated the access_token with a new value. 
- Revoked the old access_token. 
- The initially originated refresh token can be used multiple times for refreshing tokens.
- If send an invalid refresh token, it's failing the refresh.


## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
