### PR TITLE
Doc: Replace heroku service with postman in tutorial part 1

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -90,3 +90,4 @@ Víðir Valberg Guðmundsson
 Will Beaufoy
 pySilver
 Łukasz Skarżyński
+Marcus Sonestedt

--- a/docs/tutorial/tutorial_01.rst
+++ b/docs/tutorial/tutorial_01.rst
@@ -105,7 +105,7 @@ process we'll explain shortly)
 Test Your Authorization Server
 ------------------------------
 Your authorization server is ready and can begin issuing access tokens. To test the process you need an OAuth2
-consumer; if you are familiar enough with OAuth2, you can use curl, requests, or anything that speaks http. 
+consumer; if you are familiar enough with OAuth2, you can use curl, requests, or anything that speaks http.
 
 For this tutorial, we suggest using Postman, where we will be following `this guide https://columbia-it-django-jsonapi-training.readthedocs.io/en/latest/using_oauth2/#get-an-oauth-20-token`.
 

--- a/docs/tutorial/tutorial_01.rst
+++ b/docs/tutorial/tutorial_01.rst
@@ -107,7 +107,7 @@ Test Your Authorization Server
 Your authorization server is ready and can begin issuing access tokens. To test the process you need an OAuth2
 consumer; if you are familiar enough with OAuth2, you can use curl, requests, or anything that speaks http.
 
-For this tutorial, we suggest using Postman, where we will be following `this guide https://columbia-it-django-jsonapi-training.readthedocs.io/en/latest/using_oauth2/#get-an-oauth-20-token`.
+For this tutorial, we suggest using Postman.
 
 Set the fields as follows for this tutorial:
 

--- a/docs/tutorial/tutorial_01.rst
+++ b/docs/tutorial/tutorial_01.rst
@@ -138,9 +138,8 @@ again to the consumer service.
 
 Possible errors:
 
-* loginTemplate: If you are not redirected to the correct page after logging in successfully,
-you probably need to `setup your login template correctly`__.
-* invalid client: client id and client secret needs to be correct. Secret cannot be copied from Django admin after creation.
+* loginTemplate: If you are not redirected to the correct page after logging in successfully, you probably need to `setup your login template correctly`__.
+* invalid client: client id and client secret needs to be correct. Secret cannot be copied from Django admin after creation. 
   (but you can reset it by pasting the same random string into Django admin and into Postman, to avoid recreating the app)
 * invalid callback url: Add the postman link into your app in Django admin.
 * invalid_request: Use "Authorization Code (With PCKE)" from postman or disable PKCE in Django

--- a/docs/tutorial/tutorial_01.rst
+++ b/docs/tutorial/tutorial_01.rst
@@ -139,7 +139,7 @@ again to the consumer service.
 Possible errors:
 
 * loginTemplate: If you are not redirected to the correct page after logging in successfully, you probably need to `setup your login template correctly`__.
-* invalid client: client id and client secret needs to be correct. Secret cannot be copied from Django admin after creation. 
+* invalid client: client id and client secret needs to be correct. Secret cannot be copied from Django admin after creation.
   (but you can reset it by pasting the same random string into Django admin and into Postman, to avoid recreating the app)
 * invalid callback url: Add the postman link into your app in Django admin.
 * invalid_request: Use "Authorization Code (With PCKE)" from postman or disable PKCE in Django

--- a/docs/tutorial/tutorial_01.rst
+++ b/docs/tutorial/tutorial_01.rst
@@ -89,7 +89,7 @@ point your browser to http://localhost:8000/o/applications/ and add an Applicati
  * `Redirect uris`: Applications must register at least one redirection endpoint before using the
    authorization endpoint. The :term:`Authorization Server` will deliver the access token to the client only if the client
    specifies one of the verified redirection uris. For this tutorial, paste verbatim the value
-   `http://django-oauth-toolkit.herokuapp.com/consumer/exchange/`
+   `https://www.getpostman.com/oauth2/callback`
 
  * `Client type`: this value affects the security level at which some communications between the client application and
    the authorization server are performed. For this tutorial choose *Confidential*.
@@ -105,17 +105,28 @@ process we'll explain shortly)
 Test Your Authorization Server
 ------------------------------
 Your authorization server is ready and can begin issuing access tokens. To test the process you need an OAuth2
-consumer; if you are familiar enough with OAuth2, you can use curl, requests, or anything that speaks http. For the rest
-of us, there is a `consumer service <http://django-oauth-toolkit.herokuapp.com/consumer/>`_ deployed on Heroku to test
-your provider.
+consumer; if you are familiar enough with OAuth2, you can use curl, requests, or anything that speaks http. 
+
+For this tutorial, we suggest using Postman, where we will be following `this guide https://columbia-it-django-jsonapi-training.readthedocs.io/en/latest/using_oauth2/#get-an-oauth-20-token`.
+
+Set the fields as follows for this tutorial:
+
+* Grant type: `Authorization code (With PKCE)`
+* Callback URL: `https://www.getpostman.com/oauth2/callback` <- need to be in your added application
+* Authorize using browser: leave unchecked
+* Auth URL: `http://localhost:8000/o/authorize/`
+* Access Token URL: `http://localhost:8000/o/token/`
+* Client ID: `random string for this app, as generated`
+* Client Secret: `random string for this app, as generated` <- must be before hashing, should not begin with 'pbkdf2_sha256' or similar
+
+The rest can be left to their (mostly empty) default values.
 
 Build an Authorization Link for Your Users
 ++++++++++++++++++++++++++++++++++++++++++
 Authorizing an application to access OAuth2 protected data in an :term:`Authorization Code` flow is always initiated
-by the user. Your application can prompt users to click a special link to start the process. Go to the
-`Consumer <http://django-oauth-toolkit.herokuapp.com/consumer/>`_ page and complete the form by filling in your
-application's details obtained from the steps in this tutorial. Submit the form, and you'll receive a link your users can
-use to access the authorization page.
+by the user. Your application can prompt users to click a special link to start the process.
+
+Here, we click "Get New Access Token" in postman, which should open your browser and show django's login.
 
 Authorize the Application
 +++++++++++++++++++++++++
@@ -125,18 +136,20 @@ page is login protected by django-oauth-toolkit. Login, then you should see the 
 her authorization to the client application. Flag the *Allow* checkbox and click *Authorize*, you will be redirected
 again to the consumer service.
 
-__ loginTemplate_
+Possible errors:
 
-If you are not redirected to the correct page after logging in successfully,
+* loginTemplate: If you are not redirected to the correct page after logging in successfully,
 you probably need to `setup your login template correctly`__.
+* invalid client: client id and client secret needs to be correct. Secret cannot be copied from Django admin after creation.
+  (but you can reset it by pasting the same random string into Django admin and into Postman, to avoid recreating the app)
+* invalid callback url: Add the postman link into your app in Django admin.
+* invalid_request: Use "Authorization Code (With PCKE)" from postman or disable PKCE in Django
 
 Exchange the token
 ++++++++++++++++++
 At this point your authorization server redirected the user to a special page on the consumer passing in an
 :term:`Authorization Code`, a special token the consumer will use to obtain the final access token.
-This operation is usually done automatically by the client application during the request/response cycle, but we cannot
-make a POST request from Heroku to your localhost, so we proceed manually with this step. Fill the form with the
-missing data and click *Submit*.
+
 If everything is ok, you will be routed to another page showing your access token, the token type, its lifetime and
 the :term:`Refresh Token`.
 

--- a/docs/tutorial/tutorial_01.rst
+++ b/docs/tutorial/tutorial_01.rst
@@ -107,9 +107,9 @@ Test Your Authorization Server
 Your authorization server is ready and can begin issuing access tokens. To test the process you need an OAuth2
 consumer; if you are familiar enough with OAuth2, you can use curl, requests, or anything that speaks http.
 
-For this tutorial, we suggest using Postman.
+For this tutorial, we suggest using [Postman](https://www.postman.com/downloads/) :
 
-Set the fields as follows for this tutorial:
+Open up the Authorization tab under a request and, for this tutorial, set the fields as follows:
 
 * Grant type: `Authorization code (With PKCE)`
 * Callback URL: `https://www.getpostman.com/oauth2/callback` <- need to be in your added application


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #875 

## Description of the Change

Rewrite documentation to use postman and not the defunct Heroku service.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [N/A] unit-test added
- [x] documentation updated
- [N/A] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
