### PR TITLE
Remove incompatible python+django version combinations from testing.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,12 @@ jobs:
           - python-version: '3.7'
             django-version: 'main'
 
+          # < Python 3.10 is not supported by Django 5.0+
+          - python-version: '3.8'
+            django-version: 'main'
+          - python-version: '3.9'
+            django-version: 'main'
+
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
## Description of the Change
The workflow jobs for Django Main and Python < 3.10 run using Django 4.1.7 (the latest version support Python 3.8 and 3.9) instead of Django Main. This PR removes them as they provide no benefit.

This problem was fixed in the `tox.ini` with #1245. #1219 changed the workflow and reintroduced builds with Django Main against Python 3.8 and 3.9.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- n/a unit-test added
- n/a documentation updated
- n/a `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
