### PR TITLE
Fix RP-initiated Logout with expired Django session

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Allisson Azevedo
 Andrea Greco
 Andrej Zbín
 Andrew Chen Wang
+Antoine Laurent
 Anvesh Agarwal
 Aristóbulo Meneses
 Aryan Iyappan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1211 documentation improve on 'AUTHORIZATION_CODE_EXPIRE_SECONDS'.
 * #1218 Confim support for Python 3.11.
 * #1222 Remove expired ID tokens alongside access tokens in `cleartokens` management command
+* #1270 Fix RP-initiated Logout with no available Django session
 
 ## [2.2.0] 2022-10-18
 

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -536,7 +536,7 @@ def test_token_deletion_on_logout_expired_session(oidc_tokens, client, rp_settin
     )
     assert rsp.status_code == 200
     assert not is_logged_in(client)
-    # Check that all tokens have either been deleted or expired.
+    # Check that all tokens are active.
     assert AccessToken.objects.count() == 1
     assert not any([token.is_expired() for token in AccessToken.objects.all()])
     assert IDToken.objects.count() == 1

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -1,3 +1,4 @@
+from pytest_django.asserts import assertRedirects
 import pytest
 from django.contrib.auth import get_user
 from django.contrib.auth.models import AnonymousUser
@@ -552,7 +553,7 @@ def test_token_deletion_on_logout_expired_session(oidc_tokens, client, rp_settin
             "allow": True,
         },
     )
-    assert rsp.status_code == 302
+    assertRedirects(rsp, "http://testserver/", fetch_redirect_response=False)
     assert not is_logged_in(client)
     # Check that all tokens have either been deleted or expired.
     assert all(token.is_expired() for token in AccessToken.objects.all())

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -1,10 +1,10 @@
-from pytest_django.asserts import assertRedirects
 import pytest
 from django.contrib.auth import get_user
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import timezone
+from pytest_django.asserts import assertRedirects
 
 from oauth2_provider.exceptions import ClientIdMissmatch, InvalidOIDCClientError, InvalidOIDCRedirectURIError
 from oauth2_provider.models import get_access_token_model, get_id_token_model, get_refresh_token_model

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -555,9 +555,9 @@ def test_token_deletion_on_logout_expired_session(oidc_tokens, client, rp_settin
     assert rsp.status_code == 302
     assert not is_logged_in(client)
     # Check that all tokens have either been deleted or expired.
-    assert all([token.is_expired() for token in AccessToken.objects.all()])
-    assert all([token.is_expired() for token in IDToken.objects.all()])
-    assert all([token.revoked <= timezone.now() for token in RefreshToken.objects.all()])
+    assert all(token.is_expired() for token in AccessToken.objects.all())
+    assert all(token.is_expired() for token in IDToken.objects.all())
+    assert all(token.revoked <= timezone.now() for token in RefreshToken.objects.all())
 
 
 @pytest.mark.django_db

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -197,37 +197,37 @@ def test_validate_logout_request(oidc_tokens, public_application, other_user, rp
         id_token_hint=None,
         client_id=None,
         post_logout_redirect_uri=None,
-    ) == (True, (None, None))
+    ) == (True, (None, None), None)
     assert validate_logout_request(
         request=mock_request_for(oidc_tokens.user),
         id_token_hint=None,
         client_id=client_id,
         post_logout_redirect_uri=None,
-    ) == (True, (None, application))
+    ) == (True, (None, application), None)
     assert validate_logout_request(
         request=mock_request_for(oidc_tokens.user),
         id_token_hint=None,
         client_id=client_id,
         post_logout_redirect_uri="http://example.org",
-    ) == (True, ("http://example.org", application))
+    ) == (True, ("http://example.org", application), None)
     assert validate_logout_request(
         request=mock_request_for(oidc_tokens.user),
         id_token_hint=id_token,
         client_id=None,
         post_logout_redirect_uri="http://example.org",
-    ) == (ALWAYS_PROMPT, ("http://example.org", application))
+    ) == (ALWAYS_PROMPT, ("http://example.org", application), oidc_tokens.user)
     assert validate_logout_request(
         request=mock_request_for(other_user),
         id_token_hint=id_token,
         client_id=None,
         post_logout_redirect_uri="http://example.org",
-    ) == (True, ("http://example.org", application))
+    ) == (True, ("http://example.org", application), oidc_tokens.user)
     assert validate_logout_request(
         request=mock_request_for(oidc_tokens.user),
         id_token_hint=id_token,
         client_id=client_id,
         post_logout_redirect_uri="http://example.org",
-    ) == (ALWAYS_PROMPT, ("http://example.org", application))
+    ) == (ALWAYS_PROMPT, ("http://example.org", application), oidc_tokens.user)
     with pytest.raises(ClientIdMissmatch):
         validate_logout_request(
             request=mock_request_for(oidc_tokens.user),
@@ -513,6 +513,47 @@ def test_token_deletion_on_logout(oidc_tokens, loggend_in_client, rp_settings):
     )
     assert rsp.status_code == 302
     assert not is_logged_in(loggend_in_client)
+    # Check that all tokens have either been deleted or expired.
+    assert all([token.is_expired() for token in AccessToken.objects.all()])
+    assert all([token.is_expired() for token in IDToken.objects.all()])
+    assert all([token.revoked <= timezone.now() for token in RefreshToken.objects.all()])
+
+
+@pytest.mark.django_db
+def test_token_deletion_on_logout_expired_session(oidc_tokens, client, rp_settings):
+    AccessToken = get_access_token_model()
+    IDToken = get_id_token_model()
+    RefreshToken = get_refresh_token_model()
+    assert AccessToken.objects.count() == 1
+    assert IDToken.objects.count() == 1
+    assert RefreshToken.objects.count() == 1
+    rsp = client.get(
+        reverse("oauth2_provider:rp-initiated-logout"),
+        data={
+            "id_token_hint": oidc_tokens.id_token,
+            "client_id": oidc_tokens.application.client_id,
+        },
+    )
+    assert rsp.status_code == 200
+    assert not is_logged_in(client)
+    # Check that all tokens have either been deleted or expired.
+    assert AccessToken.objects.count() == 1
+    assert not any([token.is_expired() for token in AccessToken.objects.all()])
+    assert IDToken.objects.count() == 1
+    assert not any([token.is_expired() for token in IDToken.objects.all()])
+    assert RefreshToken.objects.count() == 1
+    assert not any([token.revoked is not None for token in RefreshToken.objects.all()])
+
+    rsp = client.post(
+        reverse("oauth2_provider:rp-initiated-logout"),
+        data={
+            "id_token_hint": oidc_tokens.id_token,
+            "client_id": oidc_tokens.application.client_id,
+            "allow": True,
+        },
+    )
+    assert rsp.status_code == 302
+    assert not is_logged_in(client)
     # Check that all tokens have either been deleted or expired.
     assert all([token.is_expired() for token in AccessToken.objects.all()])
     assert all([token.is_expired() for token in IDToken.objects.all()])

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -537,12 +537,12 @@ def test_token_deletion_on_logout_expired_session(oidc_tokens, client, rp_settin
     assert rsp.status_code == 200
     assert not is_logged_in(client)
     # Check that all tokens are active.
-    assert AccessToken.objects.count() == 1
-    assert not any([token.is_expired() for token in AccessToken.objects.all()])
-    assert IDToken.objects.count() == 1
-    assert not any([token.is_expired() for token in IDToken.objects.all()])
-    assert RefreshToken.objects.count() == 1
-    assert not any([token.revoked is not None for token in RefreshToken.objects.all()])
+    access_token = AccessToken.objects.get()
+    assert not access_token.is_expired()
+    id_token = IDToken.objects.get()
+    assert not id_token.is_expired()
+    refresh_token = RefreshToken.objects.get()
+    assert refresh_token.revoked is None
 
     rsp = client.post(
         reverse("oauth2_provider:rp-initiated-logout"),


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1269

## Description of the Change

Fix RP initiated logout when there's no django session available.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
