### PR TITLE
Refactor RPInitiatedLogoutView

### DIFF
--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -100,3 +100,47 @@ You might want to completely bypass the authorization form, for instance if your
 in-house product or if you already trust the application owner by other means. To this end, you have to
 set ``skip_authorization = True`` on the ``Application`` model, either programmatically or within the
 Django admin. Users will *not* be prompted for authorization, even on the first use of the application.
+
+
+.. _override-views:
+
+Overriding views
+================
+
+You may want to override whole views from Django OAuth Toolkit, for instance if you want to
+change the login view for unregistred users depending on some query params.
+
+In order to do that, you need to write a custom urlpatterns
+
+.. code-block:: python
+
+    from django.urls import re_path
+    from oauth2_provider import views as oauth2_views
+    from oauth2_provider import urls
+
+    from .views import CustomeAuthorizationView
+
+
+    app_name = "oauth2_provider"
+
+    urlpatterns = [
+        # Base urls
+        re_path(r"^authorize/", CustomeAuthorizationView.as_view(), name="authorize"),
+        re_path(r"^token/$", oauth2_views.TokenView.as_view(), name="token"),
+        re_path(r"^revoke_token/$", oauth2_views.RevokeTokenView.as_view(), name="revoke-token"),
+        re_path(r"^introspect/$", oauth2_views.IntrospectTokenView.as_view(), name="introspect"),
+    ] + urls.management_urlpatterns + urls.oidc_urlpatterns
+
+You can then remplace ``oauth2_provider.urls`` with the path to your urls file, but make sure you keep the
+same namespace as before.
+
+.. code-block:: python
+
+    from django.urls import include, path
+
+    urlpatterns = [
+        ...
+        path('o/', include('path.to.custom.urls', namespace='oauth2_provider')),
+    ]
+
+This method also allows to remove some of the urls (such as managements) urls if you don't want them.

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -131,7 +131,7 @@ In order to do that, you need to write a custom urlpatterns
         re_path(r"^introspect/$", oauth2_views.IntrospectTokenView.as_view(), name="introspect"),
     ] + urls.management_urlpatterns + urls.oidc_urlpatterns
 
-You can then remplace ``oauth2_provider.urls`` with the path to your urls file, but make sure you keep the
+You can then replace ``oauth2_provider.urls`` with the path to your urls file, but make sure you keep the
 same namespace as before.
 
 .. code-block:: python

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -209,57 +209,6 @@ def _validate_claims(request, claims):
     return True
 
 
-def validate_logout_request(request, id_token_hint, client_id, post_logout_redirect_uri):
-    """
-    Validate an OIDC RP-Initiated Logout Request.
-    `(application, token_user)` is returned.
-
-    If it is set, `application` is the Application that is requesting the logout.
-    `token_user` is the id_token user, which will used to revoke the tokens if found.
-
-    The `id_token_hint` will be validated if given. If both `client_id` and `id_token_hint` are given they
-    will be validated against each other.
-    """
-
-    id_token = None
-    if id_token_hint:
-        # Only basic validation has been done on the IDToken at this point.
-        id_token, claims = _load_id_token(id_token_hint)
-
-        if not id_token or not _validate_claims(request, claims):
-            raise InvalidIDTokenError()
-
-        # If both id_token_hint and client_id are given it must be verified that they match.
-        if client_id:
-            if id_token.application.client_id != client_id:
-                raise ClientIdMissmatch()
-
-    application = None
-    # Determine the application that is requesting the logout.
-    if client_id:
-        application = get_application_model().objects.get(client_id=client_id)
-    elif id_token:
-        application = id_token.application
-
-    # Validate `post_logout_redirect_uri`
-    if post_logout_redirect_uri:
-        if not application:
-            raise InvalidOIDCClientError()
-        scheme = urlparse(post_logout_redirect_uri)[0]
-        if not scheme:
-            raise InvalidOIDCRedirectURIError("A Scheme is required for the redirect URI.")
-        if oauth2_settings.OIDC_RP_INITIATED_LOGOUT_STRICT_REDIRECT_URIS and (
-            scheme == "http" and application.client_type != "confidential"
-        ):
-            raise InvalidOIDCRedirectURIError("http is only allowed with confidential clients.")
-        if scheme not in application.get_allowed_schemes():
-            raise InvalidOIDCRedirectURIError(f'Redirect to scheme "{scheme}" is not permitted.')
-        if not application.post_logout_redirect_uri_allowed(post_logout_redirect_uri):
-            raise InvalidOIDCRedirectURIError("This client does not have this redirect uri registered.")
-
-    return application, id_token.user if id_token else None
-
-
 class RPInitiatedLogoutView(OIDCLogoutOnlyMixin, FormView):
     template_name = "oauth2_provider/logout_confirm.html"
     form_class = ConfirmLogoutForm
@@ -298,8 +247,7 @@ class RPInitiatedLogoutView(OIDCLogoutOnlyMixin, FormView):
         state = request.GET.get("state")
 
         try:
-            application, token_user = validate_logout_request(
-                request=request,
+            application, token_user = self.validate_logout_request(
                 id_token_hint=id_token_hint,
                 client_id=client_id,
                 post_logout_redirect_uri=post_logout_redirect_uri,
@@ -330,8 +278,7 @@ class RPInitiatedLogoutView(OIDCLogoutOnlyMixin, FormView):
         state = form.cleaned_data.get("state")
 
         try:
-            application, token_user = validate_logout_request(
-                request=self.request,
+            application, token_user = self.validate_logout_request(
                 id_token_hint=id_token_hint,
                 client_id=client_id,
                 post_logout_redirect_uri=post_logout_redirect_uri,
@@ -344,6 +291,56 @@ class RPInitiatedLogoutView(OIDCLogoutOnlyMixin, FormView):
 
         except OIDCError as error:
             return self.error_response(error)
+
+    def validate_logout_request(self, id_token_hint, client_id, post_logout_redirect_uri):
+        """
+        Validate an OIDC RP-Initiated Logout Request.
+        `(application, token_user)` is returned.
+
+        If it is set, `application` is the Application that is requesting the logout.
+        `token_user` is the id_token user, which will used to revoke the tokens if found.
+
+        The `id_token_hint` will be validated if given. If both `client_id` and `id_token_hint` are given they
+        will be validated against each other.
+        """
+
+        id_token = None
+        if id_token_hint:
+            # Only basic validation has been done on the IDToken at this point.
+            id_token, claims = _load_id_token(id_token_hint)
+
+            if not id_token or not _validate_claims(self.request, claims):
+                raise InvalidIDTokenError()
+
+            # If both id_token_hint and client_id are given it must be verified that they match.
+            if client_id:
+                if id_token.application.client_id != client_id:
+                    raise ClientIdMissmatch()
+
+        application = None
+        # Determine the application that is requesting the logout.
+        if client_id:
+            application = get_application_model().objects.get(client_id=client_id)
+        elif id_token:
+            application = id_token.application
+
+        # Validate `post_logout_redirect_uri`
+        if post_logout_redirect_uri:
+            if not application:
+                raise InvalidOIDCClientError()
+            scheme = urlparse(post_logout_redirect_uri)[0]
+            if not scheme:
+                raise InvalidOIDCRedirectURIError("A Scheme is required for the redirect URI.")
+            if oauth2_settings.OIDC_RP_INITIATED_LOGOUT_STRICT_REDIRECT_URIS and (
+                scheme == "http" and application.client_type != "confidential"
+            ):
+                raise InvalidOIDCRedirectURIError("http is only allowed with confidential clients.")
+            if scheme not in application.get_allowed_schemes():
+                raise InvalidOIDCRedirectURIError(f'Redirect to scheme "{scheme}" is not permitted.')
+            if not application.post_logout_redirect_uri_allowed(post_logout_redirect_uri):
+                raise InvalidOIDCRedirectURIError("This client does not have this redirect uri registered.")
+
+        return application, id_token.user if id_token else None
 
     def must_prompt(self, token_user):
         """Indicate whether the logout has to be confirmed by the user. This happens if the

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -406,6 +406,12 @@ class RPInitiatedLogoutView(OIDCLogoutOnlyMixin, FormView):
 
         return id_token
 
+    def get_request_application(self, id_token, client_id):
+        if client_id:
+            return get_application_model().objects.get(client_id=client_id)
+        if id_token:
+            return id_token.application
+
     def validate_logout_request(self, id_token_hint, client_id, post_logout_redirect_uri):
         """
         Validate an OIDC RP-Initiated Logout Request.
@@ -419,14 +425,7 @@ class RPInitiatedLogoutView(OIDCLogoutOnlyMixin, FormView):
         """
 
         id_token = self.validate_logout_request_user(id_token_hint, client_id)
-
-        application = None
-        # Determine the application that is requesting the logout.
-        if client_id:
-            application = get_application_model().objects.get(client_id=client_id)
-        elif id_token:
-            application = id_token.application
-
+        application = self.get_request_application(id_token, client_id)
         self.validate_post_logout_redirect_uri(application, post_logout_redirect_uri)
 
         return application, id_token.user if id_token else None

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -198,37 +198,37 @@ def test_validate_logout_request(oidc_tokens, public_application, other_user, rp
         id_token_hint=None,
         client_id=None,
         post_logout_redirect_uri=None,
-    ) == (True, (None, None), None)
+    ) == (True, None, None)
     assert validate_logout_request(
         request=mock_request_for(oidc_tokens.user),
         id_token_hint=None,
         client_id=client_id,
         post_logout_redirect_uri=None,
-    ) == (True, (None, application), None)
+    ) == (True, application, None)
     assert validate_logout_request(
         request=mock_request_for(oidc_tokens.user),
         id_token_hint=None,
         client_id=client_id,
         post_logout_redirect_uri="http://example.org",
-    ) == (True, ("http://example.org", application), None)
+    ) == (True, application, None)
     assert validate_logout_request(
         request=mock_request_for(oidc_tokens.user),
         id_token_hint=id_token,
         client_id=None,
         post_logout_redirect_uri="http://example.org",
-    ) == (ALWAYS_PROMPT, ("http://example.org", application), oidc_tokens.user)
+    ) == (ALWAYS_PROMPT, application, oidc_tokens.user)
     assert validate_logout_request(
         request=mock_request_for(other_user),
         id_token_hint=id_token,
         client_id=None,
         post_logout_redirect_uri="http://example.org",
-    ) == (True, ("http://example.org", application), oidc_tokens.user)
+    ) == (True, application, oidc_tokens.user)
     assert validate_logout_request(
         request=mock_request_for(oidc_tokens.user),
         id_token_hint=id_token,
         client_id=client_id,
         post_logout_redirect_uri="http://example.org",
-    ) == (ALWAYS_PROMPT, ("http://example.org", application), oidc_tokens.user)
+    ) == (ALWAYS_PROMPT, application, oidc_tokens.user)
     with pytest.raises(ClientIdMissmatch):
         validate_logout_request(
             request=mock_request_for(oidc_tokens.user),

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -14,7 +14,6 @@ from oauth2_provider.views.oidc import (
     RPInitiatedLogoutView,
     _load_id_token,
     _validate_claims,
-    validate_logout_request,
 )
 
 from . import presets
@@ -196,67 +195,59 @@ def test_validate_logout_request(oidc_tokens, public_application):
     application = oidc_tokens.application
     client_id = application.client_id
     id_token = oidc_tokens.id_token
-    assert validate_logout_request(
-        request=mock_request_for(oidc_tokens.user),
+    view = RPInitiatedLogoutView()
+    view.request = mock_request_for(oidc_tokens.user)
+    assert view.validate_logout_request(
         id_token_hint=None,
         client_id=None,
         post_logout_redirect_uri=None,
     ) == (None, None)
-    assert validate_logout_request(
-        request=mock_request_for(oidc_tokens.user),
+    assert view.validate_logout_request(
         id_token_hint=None,
         client_id=client_id,
         post_logout_redirect_uri=None,
     ) == (application, None)
-    assert validate_logout_request(
-        request=mock_request_for(oidc_tokens.user),
+    assert view.validate_logout_request(
         id_token_hint=None,
         client_id=client_id,
         post_logout_redirect_uri="http://example.org",
     ) == (application, None)
-    assert validate_logout_request(
-        request=mock_request_for(oidc_tokens.user),
+    assert view.validate_logout_request(
         id_token_hint=id_token,
         client_id=None,
         post_logout_redirect_uri="http://example.org",
     ) == (application, oidc_tokens.user)
-    assert validate_logout_request(
-        request=mock_request_for(oidc_tokens.user),
+    assert view.validate_logout_request(
         id_token_hint=id_token,
         client_id=client_id,
         post_logout_redirect_uri="http://example.org",
     ) == (application, oidc_tokens.user)
     with pytest.raises(ClientIdMissmatch):
-        validate_logout_request(
-            request=mock_request_for(oidc_tokens.user),
+        view.validate_logout_request(
             id_token_hint=id_token,
             client_id=public_application.client_id,
             post_logout_redirect_uri="http://other.org",
         )
     with pytest.raises(InvalidOIDCClientError):
-        validate_logout_request(
-            request=mock_request_for(oidc_tokens.user),
+        view.validate_logout_request(
             id_token_hint=None,
             client_id=None,
             post_logout_redirect_uri="http://example.org",
         )
     with pytest.raises(InvalidOIDCRedirectURIError):
-        validate_logout_request(
-            request=mock_request_for(oidc_tokens.user),
+        view.validate_logout_request(
             id_token_hint=None,
             client_id=client_id,
             post_logout_redirect_uri="example.org",
         )
     with pytest.raises(InvalidOIDCRedirectURIError):
-        validate_logout_request(
-            request=mock_request_for(oidc_tokens.user),
+        view.validate_logout_request(
             id_token_hint=None,
             client_id=client_id,
             post_logout_redirect_uri="imap://example.org",
         )
     with pytest.raises(InvalidOIDCRedirectURIError):
-        validate_logout_request(
-            request=mock_request_for(oidc_tokens.user),
+        view.validate_logout_request(
             id_token_hint=None,
             client_id=client_id,
             post_logout_redirect_uri="http://other.org",

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -14,6 +14,7 @@ from oauth2_provider.views.oidc import (
     RPInitiatedLogoutView,
     _load_id_token,
     _validate_claims,
+    validate_logout_request,
 )
 
 from . import presets
@@ -187,6 +188,89 @@ def mock_request_for(user):
     request = RequestFactory().get("")
     request.user = user
     return request
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("ALWAYS_PROMPT", [True, False])
+def test_deprecated_validate_logout_request(
+    oidc_tokens, public_application, other_user, rp_settings, ALWAYS_PROMPT
+):
+    rp_settings.OIDC_RP_INITIATED_LOGOUT_ALWAYS_PROMPT = ALWAYS_PROMPT
+    oidc_tokens = oidc_tokens
+    application = oidc_tokens.application
+    client_id = application.client_id
+    id_token = oidc_tokens.id_token
+    assert validate_logout_request(
+        request=mock_request_for(oidc_tokens.user),
+        id_token_hint=None,
+        client_id=None,
+        post_logout_redirect_uri=None,
+    ) == (True, (None, None), None)
+    assert validate_logout_request(
+        request=mock_request_for(oidc_tokens.user),
+        id_token_hint=None,
+        client_id=client_id,
+        post_logout_redirect_uri=None,
+    ) == (True, (None, application), None)
+    assert validate_logout_request(
+        request=mock_request_for(oidc_tokens.user),
+        id_token_hint=None,
+        client_id=client_id,
+        post_logout_redirect_uri="http://example.org",
+    ) == (True, ("http://example.org", application), None)
+    assert validate_logout_request(
+        request=mock_request_for(oidc_tokens.user),
+        id_token_hint=id_token,
+        client_id=None,
+        post_logout_redirect_uri="http://example.org",
+    ) == (ALWAYS_PROMPT, ("http://example.org", application), oidc_tokens.user)
+    assert validate_logout_request(
+        request=mock_request_for(other_user),
+        id_token_hint=id_token,
+        client_id=None,
+        post_logout_redirect_uri="http://example.org",
+    ) == (True, ("http://example.org", application), oidc_tokens.user)
+    assert validate_logout_request(
+        request=mock_request_for(oidc_tokens.user),
+        id_token_hint=id_token,
+        client_id=client_id,
+        post_logout_redirect_uri="http://example.org",
+    ) == (ALWAYS_PROMPT, ("http://example.org", application), oidc_tokens.user)
+    with pytest.raises(ClientIdMissmatch):
+        validate_logout_request(
+            request=mock_request_for(oidc_tokens.user),
+            id_token_hint=id_token,
+            client_id=public_application.client_id,
+            post_logout_redirect_uri="http://other.org",
+        )
+    with pytest.raises(InvalidOIDCClientError):
+        validate_logout_request(
+            request=mock_request_for(oidc_tokens.user),
+            id_token_hint=None,
+            client_id=None,
+            post_logout_redirect_uri="http://example.org",
+        )
+    with pytest.raises(InvalidOIDCRedirectURIError):
+        validate_logout_request(
+            request=mock_request_for(oidc_tokens.user),
+            id_token_hint=None,
+            client_id=client_id,
+            post_logout_redirect_uri="example.org",
+        )
+    with pytest.raises(InvalidOIDCRedirectURIError):
+        validate_logout_request(
+            request=mock_request_for(oidc_tokens.user),
+            id_token_hint=None,
+            client_id=client_id,
+            post_logout_redirect_uri="imap://example.org",
+        )
+    with pytest.raises(InvalidOIDCRedirectURIError):
+        validate_logout_request(
+            request=mock_request_for(oidc_tokens.user),
+            id_token_hint=None,
+            client_id=client_id,
+            post_logout_redirect_uri="http://other.org",
+        )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->

## Description of the Change


Following this comment : https://github.com/jazzband/django-oauth-toolkit/pull/1270#issuecomment-1556033128 I tried to refactor the view.
- removing post_logout_redirect_uri from validate_logout_request outputs
- adding a must_prompt method in the view (which would additionally allow anybody to easily override it)

@dopry I didn't have a revelation on how to completely clean those multiple variables.
The fact that we need to call `validate_logout_request()` from both `form_valid()` and `'get()` does not help.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
