### PR TITLE
Allow Authorization Code flow without a client_secret - Initial commit with Patch & testcases

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Contributors
 
 Abhishek Patel
 Adam Johnson
+Adheeth P Praveen
 Alan Crosswell
 Alejandro Mantecon Guillen
 Aleksander Vaskevich

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1218 Confim support for Python 3.11.
 * #1222 Remove expired ID tokens alongside access tokens in `cleartokens` management command
 * #1270 Fix RP-initiated Logout with no available Django session
+* #1092 Allow Authorization Code flow without a client_secret
 
 ## [2.2.0] 2022-10-18
 

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -170,7 +170,7 @@ class OAuth2Validator(RequestValidator):
         # TODO: check if oauthlib has already unquoted client_id and client_secret
         try:
             client_id = request.client_id
-            client_secret = request.client_secret
+            client_secret = getattr(request, "client_secret", "")
         except AttributeError:
             return False
 


### PR DESCRIPTION
Hello @n2ygk 
Here's the PR

<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1092

## Description of the Change
Patch to address -> Allow Authorization Code flow without a client_secret #1092
Edited oauth2_provider/oauth2_validators.py and added testcases to tests/test_oauth2_validators.py
Ran tox. Seems alright


## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
