### PR TITLE
Revert "Pin flake8 version until flake8-quotes catches up."

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -101,7 +101,7 @@ basepython = python3.8
 skip_install = True
 commands = flake8 {toxinidir}
 deps =
-    flake8<6.0.0  # TODO remove this pinned version once https://github.com/zheller/flake8-quotes/pull/111 is merged.
+    flake8
     flake8-isort
     flake8-quotes
     flake8-black


### PR DESCRIPTION
This reverts commit 8f8b294130fddfe177d9144d1b2dfc60f0c8c9af.

<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->

## Description of the Change
 Unpins the flake8 version now that flake8-quotes has caught up to the breaking change.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
