### PR TITLE
🐞 fix(oidc-logout): 修复一个引发500 error的问题

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -94,3 +94,4 @@ Víðir Valberg Guðmundsson
 Will Beaufoy
 pySilver
 Łukasz Skarżyński
+Dawei Liu

--- a/oauth2_provider/exceptions.py
+++ b/oauth2_provider/exceptions.py
@@ -60,6 +60,10 @@ class InvalidIDTokenError(InvalidRequestFatalError):
     description = "The ID Token is expired, revoked, malformed, or otherwise invalid."
 
 
+class EmptyIDTokenError(InvalidRequestFatalError):
+    description = "The current request is from an anonymous user and the ID Token is empty."
+
+
 class LogoutDenied(OIDCError):
     error = "logout_denied"
     description = "Logout has been refused by the user."

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -16,12 +16,12 @@ from oauthlib.common import add_params_to_uri
 
 from ..exceptions import (
     ClientIdMissmatch,
+    EmptyIDTokenError,
     InvalidIDTokenError,
     InvalidOIDCClientError,
     InvalidOIDCRedirectURIError,
     LogoutDenied,
     OIDCError,
-    EmptyIDTokenError,
 )
 from ..forms import ConfirmLogoutForm
 from ..http import OAuth2ResponseRedirect
@@ -247,9 +247,9 @@ def validate_logout_request(request, id_token_hint, client_id, post_logout_redir
             if id_token.application.client_id != client_id:
                 raise ClientIdMissmatch()
     else:
-        # Returns a 400 error 
+        # Returns a 400 error
         # when no id_token_hint is provided and it is impossible to confirm who the request came from
-        if isinstance(request.user,AnonymousUser):
+        if isinstance(request.user, AnonymousUser):
             raise EmptyIDTokenError()
 
     # The standard states that a prompt should always be shown.

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -6,7 +6,12 @@ from django.urls import reverse
 from django.utils import timezone
 from pytest_django.asserts import assertRedirects
 
-from oauth2_provider.exceptions import ClientIdMissmatch, InvalidOIDCClientError, InvalidOIDCRedirectURIError
+from oauth2_provider.exceptions import (
+    ClientIdMissmatch,
+    EmptyIDTokenError,
+    InvalidOIDCClientError,
+    InvalidOIDCRedirectURIError,
+)
 from oauth2_provider.models import get_access_token_model, get_id_token_model, get_refresh_token_model
 from oauth2_provider.oauth2_validators import OAuth2Validator
 from oauth2_provider.settings import oauth2_settings
@@ -263,6 +268,13 @@ def test_validate_logout_request(oidc_tokens, public_application, other_user, rp
             id_token_hint=None,
             client_id=client_id,
             post_logout_redirect_uri="http://other.org",
+        )
+    with pytest.raises(EmptyIDTokenError):
+        validate_logout_request(
+            request=mock_request(),
+            id_token_hint=None,
+            client_id=None,
+            post_logout_redirect_uri=None,
         )
 
 


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1280

## Description of the Change

Returns a 400 error when no id_token_hint is provided and it is impossible to confirm who the request came from

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
