### PR TITLE
Fix RP Initiated Logout when no user is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * #1273 Add caching of loading of OIDC private key.
 
+- ### Fixed
+* #1284 Allow to logout whith no id_token_hint even if the browser session already expired
+
 ## [2.3.0] 2023-05-31
 
 ### WARNING

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -2,6 +2,7 @@ import json
 from urllib.parse import urlparse
 
 from django.contrib.auth import logout
+from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponse, JsonResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -362,12 +363,13 @@ class RPInitiatedLogoutView(OIDCLogoutOnlyMixin, FormView):
             return self.error_response(error)
 
     def do_logout(self, application=None, post_logout_redirect_uri=None, state=None, token_user=None):
-        # Delete Access Tokens
-        if oauth2_settings.OIDC_RP_INITIATED_LOGOUT_DELETE_TOKENS:
+        user = token_user or self.request.user
+        # Delete Access Tokens if a user was found
+        if oauth2_settings.OIDC_RP_INITIATED_LOGOUT_DELETE_TOKENS and not isinstance(user, AnonymousUser):
             AccessToken = get_access_token_model()
             RefreshToken = get_refresh_token_model()
             access_tokens_to_delete = AccessToken.objects.filter(
-                user=token_user or self.request.user,
+                user=user,
                 application__client_type__in=self.token_deletion_client_types,
                 application__authorization_grant_type__in=self.token_deletion_grant_types,
             )

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -402,6 +402,15 @@ def test_rp_initiated_logout_post_allowed(logged_in_client, oidc_tokens, rp_sett
 
 
 @pytest.mark.django_db
+def test_rp_initiated_logout_post_no_session(client, oidc_tokens, rp_settings):
+    form_data = {"client_id": oidc_tokens.application.client_id, "allow": True}
+    rsp = client.post(reverse("oauth2_provider:rp-initiated-logout"), form_data)
+    assert rsp.status_code == 302
+    assert rsp["Location"] == "http://testserver/"
+    assert not is_logged_in(client)
+
+
+@pytest.mark.django_db
 @pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RP_LOGOUT)
 def test_rp_initiated_logout_expired_tokens_accept(logged_in_client, application, expired_id_token):
     # Accepting expired (but otherwise valid and signed by us) tokens is enabled. Logout should go through.


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1280

## Description of the Change

Don't crash when we only have a AnonymousUser to logout (no id_token_hint or existing session), 

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
