### PR TITLE
Allow to disable applications management views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * #1273 Add caching of loading of OIDC private key.
+* #1286 Add setting to disable management views
 
 ## [2.3.0] 2023-05-31
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -271,8 +271,11 @@ According to `OAuth 2.0 Security Best Current Practice <https://oauth.net/2/oaut
 - For confidential clients, the use of PKCE `RFC7636 <https://datatracker.ietf.org/doc/html/rfc7636>`_ is RECOMMENDED.
 
 
+MANAGEMENT_VIEWS_ENABLED
+~~~~~~~~~~~~~~~~~~~~~~~~
+Default: ``True``
 
-
+Whether or not the applications management views are enabled.
 
 
 OIDC_RSA_PRIVATE_KEY

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -108,6 +108,8 @@ DEFAULTS = {
     "ALWAYS_RELOAD_OAUTHLIB_CORE": False,
     "CLEAR_EXPIRED_TOKENS_BATCH_SIZE": 10000,
     "CLEAR_EXPIRED_TOKENS_BATCH_INTERVAL": 0,
+    # Whether or not to enable management views
+    "MANAGEMENT_VIEWS_ENABLED": True,
 }
 
 # List of settings that cannot be empty

--- a/oauth2_provider/urls.py
+++ b/oauth2_provider/urls.py
@@ -1,6 +1,7 @@
 from django.urls import re_path
 
 from . import views
+from .settings import oauth2_settings
 
 
 app_name = "oauth2_provider"
@@ -30,6 +31,7 @@ management_urlpatterns = [
     ),
 ]
 
+
 oidc_urlpatterns = [
     re_path(
         r"^\.well-known/openid-configuration/$",
@@ -42,4 +44,7 @@ oidc_urlpatterns = [
 ]
 
 
-urlpatterns = base_urlpatterns + management_urlpatterns + oidc_urlpatterns
+urlpatterns = base_urlpatterns
+if oauth2_settings.MANAGEMENT_VIEWS_ENABLED:
+    urlpatterns += management_urlpatterns
+urlpatterns += oidc_urlpatterns

--- a/tests/test_application_views.py
+++ b/tests/test_application_views.py
@@ -1,6 +1,7 @@
 import pytest
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.urls import reverse
 
 from oauth2_provider.models import get_application_model
@@ -99,3 +100,24 @@ class TestApplicationViews(BaseTest):
 
         response = self.client.get(reverse("oauth2_provider:detail", args=(self.app_bar_1.pk,)))
         self.assertEqual(response.status_code, 404)
+
+    @override_settings(OAUTH2_PROVIDER={"MANAGEMENT_VIEWS_ENABLED": False})
+    def test_setting(self):
+        self.client.login(username="foo_user", password="123456")
+
+        urls = [
+            "/o/applications/",
+            "/o/applications/register/",
+            "/o/applications/1/",
+            "/o/applications/1/delete/",
+            "/o/applications/1/update/",
+            "/o/applications/1/authorized_tokens/",
+        ]
+
+        for url in urls:
+            print(url)
+            response = self.client.get(url)
+            print(response.status_code)
+            if response.status_code == 302:
+                print(response.url)
+            self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
## Description of the Change

Add a setting to disable management views.

Without this, anybody can use the urls to add an application, which could lead to a breach in security (typically if the application can be used to retrieve data from an API).

I think it would be better to make the default False, but It would be a backward-incompatible change for every project using these URLs. 

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
