### PR TITLE
Update RFC URLs to modern location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ If you are facing one or more of the following:
 Django OAuth Toolkit can help you providing out of the box all the endpoints, data and logic needed to add OAuth2
 capabilities to your Django projects. Django OAuth Toolkit makes extensive use of the excellent
 `OAuthLib <https://github.com/idan/oauthlib>`_, so that everything is
-`rfc-compliant <http://tools.ietf.org/html/rfc6749>`_.
+`rfc-compliant <https://rfc-editor.org/rfc/rfc6749.html>`_.
 
 Reporting security issues
 -------------------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -416,7 +416,7 @@ Next step is :doc:`first tutorial <tutorial/tutorial_01>`.
 .. _Whitson Gordon: https://en.wikipedia.org/wiki/OAuth#cite_note-1
 .. _User: https://docs.djangoproject.com/en/3.0/ref/contrib/auth/#django.contrib.auth.models.User
 .. _Django documentation: https://docs.djangoproject.com/en/3.0/topics/auth/customizing/#using-a-custom-user-model-when-starting-a-project
-.. _RFC6749: https://tools.ietf.org/html/rfc6749#section-1.3
+.. _RFC6749: https://rfc-editor.org/rfc/rfc6749.html#section-1.3
 .. _Grant Types: https://oauth.net/2/grant-types/
 .. _URL: http://127.0.0.1:8000/o/authorize/?response_type=code&client_id=vW1RcAl7Mb0d5gyHNQIAcH110lWoOW2BmWJIero8&redirect_uri=http://127.0.0.1:8000/noexist/callback
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Welcome to Django OAuth Toolkit Documentation
 Django OAuth Toolkit can help you by providing, out of the box, all the endpoints, data, and logic needed to add OAuth2
 capabilities to your Django projects. Django OAuth Toolkit makes extensive use of the excellent
 `OAuthLib <https://github.com/idan/oauthlib>`_, so that everything is
-`rfc-compliant <http://tools.ietf.org/html/rfc6749>`_.
+`rfc-compliant <https://rfc-editor.org/rfc/rfc6749.html>`_.
 
 See our :doc:`Changelog <changelog>` for information on updates.
 

--- a/docs/resource_server.rst
+++ b/docs/resource_server.rst
@@ -1,7 +1,7 @@
 Separate Resource Server
 ========================
 Django OAuth Toolkit allows to separate the :term:`Authorization Server` and the :term:`Resource Server`.
-Based on the `RFC 7662 <https://tools.ietf.org/html/rfc7662>`_ Django OAuth Toolkit provides
+Based on the `RFC 7662 <https://rfc-editor.org/rfc/rfc7662.html>`_ Django OAuth Toolkit provides
 a rfc-compliant introspection endpoint.
 As well the Django OAuth Toolkit allows to verify access tokens by the use of an introspection endpoint.
 

--- a/docs/rfc.py
+++ b/docs/rfc.py
@@ -4,7 +4,7 @@ Custom Sphinx documentation module to link to parts of the OAuth2 RFC.
 from docutils import nodes
 
 
-base_url = "http://tools.ietf.org/html/rfc6749"
+base_url = "https://rfc-editor.org/rfc/rfc6749.html"
 
 
 def rfclink(name, rawtext, text, lineno, inliner, options={}, content=[]):

--- a/docs/tutorial/tutorial_04.rst
+++ b/docs/tutorial/tutorial_04.rst
@@ -9,7 +9,7 @@ Revoking a Token
 ----------------
 Be sure that you've granted a valid token. If you've hooked in `oauth-toolkit` into your `urls.py` as specified in :doc:`part 1 <tutorial_01>`, you'll have a URL at `/o/revoke_token`. By submitting the appropriate request to that URL, you can revoke a user's :term:`Access Token`.
 
-`Oauthlib <https://github.com/idan/oauthlib>`_ is compliant with https://tools.ietf.org/html/rfc7009, so as specified, the revocation request requires:
+`Oauthlib <https://github.com/idan/oauthlib>`_ is compliant with https://rfc-editor.org/rfc/rfc7009.html, so as specified, the revocation request requires:
 
 - token:  REQUIRED, this is the :term:`Access Token` you want to revoke
 - token_type_hint: OPTIONAL, designating either 'access_token' or 'refresh_token'.

--- a/oauth2_provider/generators.py
+++ b/oauth2_provider/generators.py
@@ -17,7 +17,7 @@ class ClientIdGenerator(BaseHashGenerator):
     def hash(self):
         """
         Generate a client_id for Basic Authentication scheme without colon char
-        as in http://tools.ietf.org/html/rfc2617#section-2
+        as in https://rfc-editor.org/rfc/rfc2617.html#section-2
         """
         return oauthlib_generate_client_id(length=40, chars=UNICODE_ASCII_CHARACTER_SET)
 

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -536,7 +536,7 @@ class OAuth2Validator(RequestValidator):
         Save access and refresh token, If refresh token is issued, remove or
         reuse old refresh token as in rfc:`6`
 
-        @see: https://tools.ietf.org/html/draft-ietf-oauth-v2-31#page-43
+        @see: https://rfc-editor.org/rfc/rfc6749.html#section-6
         """
 
         if "scope" not in token:

--- a/oauth2_provider/views/introspect.py
+++ b/oauth2_provider/views/introspect.py
@@ -13,7 +13,7 @@ from oauth2_provider.views.generic import ClientProtectedScopedResourceView
 class IntrospectTokenView(ClientProtectedScopedResourceView):
     """
     Implements an endpoint for token introspection based
-    on RFC 7662 https://tools.ietf.org/html/rfc7662
+    on RFC 7662 https://rfc-editor.org/rfc/rfc7662.html
 
     To access this view the request must pass a OAuth2 Bearer Token
     which is allowed to access the scope `introspection`.

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -483,7 +483,7 @@ class TestAuthorizationCodeView(BaseTest):
         """
         Tests that a redirection uri with query string is allowed
         and query string is retained on redirection.
-        See http://tools.ietf.org/html/rfc6749#section-3.1.2
+        See https://rfc-editor.org/rfc/rfc6749.html#section-3.1.2
         """
         self.client.login(username="test_user", password="123456")
 

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -690,7 +690,7 @@ class TestHybridView(BaseTest):
         """
         Tests that a redirection uri with query string is allowed
         and query string is retained on redirection.
-        See http://tools.ietf.org/html/rfc6749#section-3.1.2
+        See https://rfc-editor.org/rfc/rfc6749.html#section-3.1.2
         """
         self.client.login(username="hy_test_user", password="123456")
 
@@ -713,7 +713,7 @@ class TestHybridView(BaseTest):
         """
         Tests that a redirection uri with query string is allowed
         and query string is retained on redirection.
-        See http://tools.ietf.org/html/rfc6749#section-3.1.2
+        See https://rfc-editor.org/rfc/rfc6749.html#section-3.1.2
         """
         self.client.login(username="hy_test_user", password="123456")
 
@@ -737,7 +737,7 @@ class TestHybridView(BaseTest):
         """
         Tests that a redirection uri with query string is allowed
         and query string is retained on redirection.
-        See http://tools.ietf.org/html/rfc6749#section-3.1.2
+        See https://rfc-editor.org/rfc/rfc6749.html#section-3.1.2
         """
         self.client.login(username="hy_test_user", password="123456")
 

--- a/tests/test_implicit.py
+++ b/tests/test_implicit.py
@@ -205,7 +205,7 @@ class TestImplicitAuthorizationCodeView(BaseTest):
         """
         Tests that a redirection uri with query string is allowed
         and query string is retained on redirection.
-        See http://tools.ietf.org/html/rfc6749#section-3.1.2
+        See https://rfc-editor.org/rfc/rfc6749.html#section-3.1.2
         """
         self.client.login(username="test_user", password="123456")
 

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -311,7 +311,7 @@ class TestOAuth2ValidatorProvidesErrorData(TransactionTestCase):
     """These test cases check that the recommended error codes are returned
     when token authentication fails.
 
-    RFC-6750: https://tools.ietf.org/html/rfc6750
+    RFC-6750: https://rfc-editor.org/rfc/rfc6750.html
 
     > If the protected resource request does not include authentication
     > credentials or does not contain an access token that enables access
@@ -331,7 +331,7 @@ class TestOAuth2ValidatorProvidesErrorData(TransactionTestCase):
     > attribute to provide the client with the reason why the access
     > request was declined.
 
-    See https://tools.ietf.org/html/rfc6750#section-3.1 for the allowed error
+    See https://rfc-editor.org/rfc/rfc6750.html#section-3.1 for the allowed error
     codes.
     """
 


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1313

## Description of the Change
This updates RFC references that pointed at now-deprecated `tools.ietf.org` to use `rfc-editor.org` instead. Several links were updated from http to https. A reference in `oauth2_validators.py` was still referring to an old revision of the pre-RFC draft, so I've updated that to the corresponding section of the published RFC (the text in that section looked unchanged at a glance).

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
