### PR TITLE
Resolved documentation issue with Code Verifier and Code Challenge

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -80,6 +80,7 @@ Paul Oswald
 Pavel Tvrdík
 Peter Carnesciali
 Peter Karman
+Peter McDonald
 Petr Dlouhý
 Rodney Richardson
 Rustem Saiargaliev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1311 Add option to disable client_secret hashing to allow verifying JWTs' signatures.
 
 - ### Fixed
-* #1284 Allow to logout whith no id_token_hint even if the browser session already expired
+* #1322 Instructions in documentation on how to create a code challenge and code verifier
+* #1284 Allow to logout with no id_token_hint even if the browser session already expired
 * #1296 Added reverse function in migration 0006_alter_application_client_secret
 
 ## [2.3.0] 2023-05-31

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -268,9 +268,8 @@ Now let's generate an authentication code grant with PKCE (Proof Key for Code Ex
     import hashlib
 
     code_verifier = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(random.randint(43, 128)))
-    code_verifier = base64.urlsafe_b64encode(code_verifier.encode('utf-8'))
 
-    code_challenge = hashlib.sha256(code_verifier).digest()
+    code_challenge = hashlib.sha256(code_verifier.encode('utf-8')).digest()
     code_challenge = base64.urlsafe_b64encode(code_challenge).decode('utf-8').replace('=', '')
 
 Take note of ``code_challenge`` since we will include it in the code flow URL. It should look something like ``XRi41b-5yHtTojvCpXFpsLUnmGFz6xR15c3vpPANAvM``.


### PR DESCRIPTION
Fixes #1322

## Description of the Change

This resolves an issue with the instructions for generating a code challenge and code verifier. Following the instructions resulted in an error rather than getting the correct token details.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
