### PR TITLE
Adds the ability to define how to store a user

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -341,9 +341,7 @@ class OAuth2Validator(RequestValidator):
 
         Returns an UserModel instance;
         """
-        user, _ = UserModel.objects.get_or_create(
-            **{UserModel.USERNAME_FIELD: content["username"]}
-        )
+        user, _ = UserModel.objects.get_or_create(**{UserModel.USERNAME_FIELD: content["username"]})
         return user
 
     def _get_token_from_authentication_server(


### PR DESCRIPTION
## Description of the Change
Faced a problem that it is not possible now to specify the user's storage location in the validator. This functionality is now a separate public method that can be easily reused. If you agree with me, I will implement the rest of the checklist items (tests, docs, etc.).

## Checklist
- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
