### PR TITLE
fix: rtd build missing dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,6 @@ Django
 oauthlib>=3.1.0
 m2r>=0.2.1
 mistune<2
+sphinx==7.2.6
+sphinx-rtd-theme==1.3.0
 -e .


### PR DESCRIPTION
see: https://blog.readthedocs.com/defaulting-latest-build-tools/

Fixes #1330

## Description of the Change

add missing requirements

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [X] PR only contains one change (considered splitting up PR)
- [N/A] unit-test added 
- [N/A] documentation updated 
- [N/A] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
