### PR TITLE
fix: AUTHORS alpha sort

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -71,6 +71,7 @@ Jun Zhou
 Kaleb Porter
 Kristian Rune Larsen
 Ludwig Hähne
+Łukasz Skarżyński
 Marcus Sonestedt
 Matias Seniquiel
 Michael Howitz
@@ -83,6 +84,7 @@ Peter Carnesciali
 Peter Karman
 Peter McDonald
 Petr Dlouhý
+pySilver
 Rodney Richardson
 Rustem Saiargaliev
 Rustem Saiargaliev
@@ -97,6 +99,4 @@ Tom Evans
 Vinay Karanam
 Víðir Valberg Guðmundsson
 Will Beaufoy
-pySilver
-Łukasz Skarżyński
 Yuri Savin


### PR DESCRIPTION
- L with stroke should be treated as L
- pySilver out of place, do we need a real name here for posterity?


## Description of the Change
fix sort in AUTHORS file

## Checklist

- [X] PR only contains one change (considered splitting up PR)
- [N/A] unit-test added
- [N/A] documentation updated
- [N/A] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
