### PR TITLE
Fix unhashed secret to work with request body authentication.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Alan Crosswell
 Alejandro Mantecon Guillen
 Aleksander Vaskevich
 Alessandro De Angelis
+Alex Manning
 Alex Szabó
 Allisson Azevedo
 Andrea Greco

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -190,7 +190,7 @@ class OAuth2Validator(RequestValidator):
         if self._load_application(client_id, request) is None:
             log.debug("Failed body auth: Application %s does not exists" % client_id)
             return False
-        elif not check_password(client_secret, request.client.client_secret):
+        elif not self._check_secret(client_secret, request.client.client_secret):
             log.debug("Failed body auth: wrong client secret %s" % client_secret)
             return False
         else:

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -100,6 +100,18 @@ class TestOAuth2Validator(TransactionTestCase):
         self.blank_secret_request.client_secret = "wrong_client_secret"
         self.assertFalse(self.validator._authenticate_request_body(self.blank_secret_request))
 
+    def test_authenticate_request_body_unhashed_secret(self):
+        self.application.client_secret = CLEARTEXT_SECRET
+        self.application.hash_client_secret = False
+        self.application.save()
+
+        self.request.client_id = "client_id"
+        self.request.client_secret = CLEARTEXT_SECRET
+        self.assertTrue(self.validator._authenticate_request_body(self.request))
+
+        self.application.hash_client_secret = True
+        self.application.save()
+
     def test_extract_basic_auth(self):
         self.request.headers = {"HTTP_AUTHORIZATION": "Basic 123456"}
         self.assertEqual(self.validator._extract_basic_auth(self.request), "123456")


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->

## Description of the Change
#1311 allowed the use of unhashed client secrets, but if a secret is unhashed it does not work if the client includes it's client_id and client_secret in the request body, instead of using basic auth- only hashed secrets work in that case.

This PR allows hashed or unhashed secrets in _authenticate_request_body too, and adds a test for this case.

I think this is small enough that it can really just be considered part of 1311 in terms of documentation and changelog- but if I'm wrong please let me know and I can come back.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
