### PR TITLE
Fix access token 500

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,6 +26,7 @@ Antoine Laurent
 Anvesh Agarwal
 Aristóbulo Meneses
 Aryan Iyappan
+Asaf Klibansky
 Ash Christopher
 Asif Saif Uddin
 Bart Merenda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1273 Add caching of loading of OIDC private key.
 * #1285 Add post_logout_redirect_uris field in application views.
 * #1311 Add option to disable client_secret hashing to allow verifying JWTs' signatures.
+* #1337 Gracefully handle expired or deleted refresh tokens, in `validate_user`.
 
 - ### Fixed
 * #1322 Instructions in documentation on how to create a code challenge and code verifier

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -729,7 +729,7 @@ class OAuth2Validator(RequestValidator):
             try:
                 return AccessToken.objects.get(source_refresh_token_id=rt.id).scope
             except AccessToken.DoesNotExist:
-                return None
+                return []
         return rt.access_token.scope
 
     def validate_refresh_token(self, refresh_token, client, request, *args, **kwargs):

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -726,8 +726,10 @@ class OAuth2Validator(RequestValidator):
         # validate_refresh_token.
         rt = request.refresh_token_instance
         if not rt.access_token_id:
-            return AccessToken.objects.get(source_refresh_token_id=rt.id).scope
-
+            try:
+                return AccessToken.objects.get(source_refresh_token_id=rt.id).scope
+            except AccessToken.DoesNotExist:
+                return None
         return rt.access_token.scope
 
     def validate_refresh_token(self, refresh_token, client, request, *args, **kwargs):

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -881,21 +881,34 @@ class TestAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
         response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
         self.assertEqual(response.status_code, 400)
 
-    def test_refresh_fails_with_bad_token(self):
+    def test_refresh_fails_with_deleted_token(self):
         """
-        Request an access token using a refresh token and passing scopes
+        Ensure that using a deleted refresh token returns 400
         """
         self.client.login(username="test_user", password="123456")
+        authorization_code = self.get_auth()
 
         token_request_data = {
-            "grant_type": "refresh_token",
-            "refresh_token": "bad_token",
-            "scope": "read write",
+            "grant_type": "authorization_code",
+            "code": authorization_code,
+            "redirect_uri": "http://example.org",
         }
         auth_headers = get_basic_auth_header(self.application.client_id, CLEARTEXT_SECRET)
 
         response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
+        content = json.loads(response.content.decode("utf-8"))
 
+        rt = content["refresh_token"]
+
+        RefreshToken.objects.filter(token=rt).delete()
+
+        token_request_data = {
+            "grant_type": "refresh_token",
+            "refresh_token": rt,
+            "scope": content["scope"],
+        }
+
+        response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
         self.assertEqual(response.status_code, 400)
 
     def test_refresh_no_scopes(self):

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -851,6 +851,36 @@ class TestAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
         self.assertIsNotNone(refresh_token.revoked)
         self.assertFalse(AccessToken.objects.filter(token=at).exists())
 
+    def test_refresh_twice_with_same_token_returns_401(self):
+        """
+        Ensure that using a refresh token twice returns 401
+        """
+        self.client.login(username="test_user", password="123456")
+        authorization_code = self.get_auth()
+
+        token_request_data = {
+            "grant_type": "authorization_code",
+            "code": authorization_code,
+            "redirect_uri": "http://example.org",
+        }
+        auth_headers = get_basic_auth_header(self.application.client_id, CLEARTEXT_SECRET)
+
+        response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
+        content = json.loads(response.content.decode("utf-8"))
+
+        rt = content["refresh_token"]
+
+        token_request_data = {
+            "grant_type": "refresh_token",
+            "refresh_token": rt,
+            "scope": content["scope"],
+        }
+        response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
+        self.assertEqual(response.status_code, 400)
+
     def test_refresh_no_scopes(self):
         """
         Request an access token using a refresh token without passing any scope

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -851,9 +851,9 @@ class TestAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
         self.assertIsNotNone(refresh_token.revoked)
         self.assertFalse(AccessToken.objects.filter(token=at).exists())
 
-    def test_refresh_twice_with_same_token_returns_401(self):
+    def test_refresh_twice_with_same_token_returns_400(self):
         """
-        Ensure that using a refresh token twice returns 401
+        Ensure that using a refresh token twice returns 400
         """
         self.client.login(username="test_user", password="123456")
         authorization_code = self.get_auth()

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -881,6 +881,23 @@ class TestAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
         response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
         self.assertEqual(response.status_code, 400)
 
+    def test_refresh_fails_with_bad_token(self):
+        """
+        Request an access token using a refresh token and passing scopes
+        """
+        self.client.login(username="test_user", password="123456")
+
+        token_request_data = {
+            "grant_type": "refresh_token",
+            "refresh_token": "bad_token",
+            "scope": "read write",
+        }
+        auth_headers = get_basic_auth_header(self.application.client_id, CLEARTEXT_SECRET)
+
+        response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
+
+        self.assertEqual(response.status_code, 400)
+
     def test_refresh_no_scopes(self):
         """
         Request an access token using a refresh token without passing any scope


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes https://github.com/jazzband/django-oauth-toolkit/issues/1318

## Description of the Change
We are now try / except when attempting to find a vali token to avoid a 500 `oauth2_provider.models.AccessToken.DoesNotExist: AccessToken matching query does not exist`

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
