### PR TITLE
feat: update test idp to use new cors

### DIFF
--- a/tests/app/idp/idp/apps.py
+++ b/tests/app/idp/idp/apps.py
@@ -1,0 +1,14 @@
+from corsheaders.signals import check_request_enabled
+from django.apps import AppConfig
+
+
+def cors_allow_origin(sender, request, **kwargs):
+    return request.path == "/o/userinfo/" or request.path == "/o/userinfo"
+
+
+class IDPAppConfig(AppConfig):
+    name = "idp"
+    default = True
+
+    def ready(self):
+        check_request_enabled.connect(cors_allow_origin)

--- a/tests/app/idp/idp/settings.py
+++ b/tests/app/idp/idp/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
+import os
 from pathlib import Path
 
 
@@ -32,6 +33,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    "idp.apps.IDPAppConfig",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -186,10 +188,10 @@ ipUMvb4Se0LDJnmFuv8v6gM6V4vyXkP855mNOiRHUOHOSKdQ3SeKrLlnR6I=
     "SCOPES": {
         "openid": "OpenID Connect scope",
     },
+    "ALLOWED_SCHEMES": ["https", "http"],
 }
-
-# just for this example
-CORS_ORIGIN_ALLOW_ALL = True
+# needs to be set to allow cors requests from the test app, along with ALLOWED_SCHEMES=["http"]
+os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
 
 LOGGING = {
     "version": 1,
@@ -210,5 +212,11 @@ LOGGING = {
             "level": "DEBUG",
             "propagate": False,
         },
+        # occasionally you may want to see what's going on in upstream in oauthlib
+        # "oauthlib": {
+        #     "handlers": ["console"],
+        #     "level": "DEBUG",
+        #     "propagate": False,
+        # },
     },
 }


### PR DESCRIPTION
## Description of the Change

Use updated CORS support for /token in tests/app/idp to use the work from #1229. The corsheaders app is still used for the userinfo endpoint.  

I also updated the CHANGELOG.md with the Add from #1229 since I made a mess of that merge.

## Checklist

- [X] PR only contains one change (considered splitting up PR)
- [N/A] unit-test added
- [N/A] documentation updated
- [X] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
