### PR TITLE
Speed up tests ~2x

### DIFF
--- a/tests/test_application_views.py
+++ b/tests/test_application_views.py
@@ -14,13 +14,10 @@ UserModel = get_user_model()
 
 
 class BaseTest(TestCase):
-    def setUp(self):
-        self.foo_user = UserModel.objects.create_user("foo_user", "test@example.com", "123456")
-        self.bar_user = UserModel.objects.create_user("bar_user", "dev@example.com", "123456")
-
-    def tearDown(self):
-        self.foo_user.delete()
-        self.bar_user.delete()
+    @classmethod
+    def setUpTestData(cls):
+        cls.foo_user = UserModel.objects.create_user("foo_user", "test@example.com", "123456")
+        cls.bar_user = UserModel.objects.create_user("bar_user", "dev@example.com", "123456")
 
 
 @pytest.mark.usefixtures("oauth2_settings")
@@ -67,8 +64,9 @@ class TestApplicationRegistrationView(BaseTest):
 
 
 class TestApplicationViews(BaseTest):
-    def _create_application(self, name, user):
-        app = Application.objects.create(
+    @classmethod
+    def _create_application(cls, name, user):
+        return Application.objects.create(
             name=name,
             redirect_uris="http://example.com",
             post_logout_redirect_uris="http://other_example.com",
@@ -76,20 +74,16 @@ class TestApplicationViews(BaseTest):
             authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
             user=user,
         )
-        return app
 
-    def setUp(self):
-        super().setUp()
-        self.app_foo_1 = self._create_application("app foo_user 1", self.foo_user)
-        self.app_foo_2 = self._create_application("app foo_user 2", self.foo_user)
-        self.app_foo_3 = self._create_application("app foo_user 3", self.foo_user)
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.app_foo_1 = cls._create_application("app foo_user 1", cls.foo_user)
+        cls.app_foo_2 = cls._create_application("app foo_user 2", cls.foo_user)
+        cls.app_foo_3 = cls._create_application("app foo_user 3", cls.foo_user)
 
-        self.app_bar_1 = self._create_application("app bar_user 1", self.bar_user)
-        self.app_bar_2 = self._create_application("app bar_user 2", self.bar_user)
-
-    def tearDown(self):
-        super().tearDown()
-        get_application_model().objects.all().delete()
+        cls.app_bar_1 = cls._create_application("app bar_user 1", cls.bar_user)
+        cls.app_bar_2 = cls._create_application("app bar_user 2", cls.bar_user)
 
     def test_application_list(self):
         self.client.login(username="foo_user", password="123456")

--- a/tests/test_auth_backends.py
+++ b/tests/test_auth_backends.py
@@ -24,23 +24,20 @@ class BaseTest(TestCase):
     Base class for cases in this module
     """
 
-    def setUp(self):
-        self.user = UserModel.objects.create_user("user", "test@example.com", "123456")
-        self.app = ApplicationModel.objects.create(
+    factory = RequestFactory()
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserModel.objects.create_user("user", "test@example.com", "123456")
+        cls.app = ApplicationModel.objects.create(
             name="app",
             client_type=ApplicationModel.CLIENT_CONFIDENTIAL,
             authorization_grant_type=ApplicationModel.GRANT_CLIENT_CREDENTIALS,
-            user=self.user,
+            user=cls.user,
         )
-        self.token = AccessTokenModel.objects.create(
-            user=self.user, token="tokstr", application=self.app, expires=now() + timedelta(days=365)
+        cls.token = AccessTokenModel.objects.create(
+            user=cls.user, token="tokstr", application=cls.app, expires=now() + timedelta(days=365)
         )
-        self.factory = RequestFactory()
-
-    def tearDown(self):
-        self.user.delete()
-        self.app.delete()
-        self.token.delete()
 
 
 class TestOAuth2Backend(BaseTest):
@@ -103,10 +100,6 @@ class TestOAuth2Backend(BaseTest):
     }
 )
 class TestOAuth2Middleware(BaseTest):
-    def setUp(self):
-        super().setUp()
-        self.anon_user = AnonymousUser()
-
     def dummy_get_response(self, request):
         return HttpResponse()
 
@@ -131,7 +124,7 @@ class TestOAuth2Middleware(BaseTest):
         request.user = self.user
         m(request)
         self.assertIs(request.user, self.user)
-        request.user = self.anon_user
+        request.user = AnonymousUser()
         m(request)
         self.assertEqual(request.user.pk, self.user.pk)
 
@@ -176,10 +169,6 @@ class TestOAuth2Middleware(BaseTest):
     }
 )
 class TestOAuth2ExtraTokenMiddleware(BaseTest):
-    def setUp(self):
-        super().setUp()
-        self.anon_user = AnonymousUser()
-
     def dummy_get_response(self, request):
         return HttpResponse()
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -14,26 +14,24 @@ UserModel = get_user_model()
 
 
 class TestProtectedResourceDecorator(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.request_factory = RequestFactory()
-        super().setUpClass()
+    request_factory = RequestFactory()
 
-    def setUp(self):
-        self.user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
-        self.application = Application.objects.create(
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
+        cls.application = Application.objects.create(
             name="test_client_credentials_app",
-            user=self.user,
+            user=cls.user,
             client_type=Application.CLIENT_PUBLIC,
             authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
         )
 
-        self.access_token = AccessToken.objects.create(
-            user=self.user,
+        cls.access_token = AccessToken.objects.create(
+            user=cls.user,
             scope="read write",
             expires=timezone.now() + timedelta(seconds=300),
             token="secret-access-token-key",
-            application=self.application,
+            application=cls.application,
         )
 
     def test_access_denied(self):

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -48,30 +48,29 @@ class ScopedResourceView(ScopedProtectedResourceView):
 
 @pytest.mark.usefixtures("oauth2_settings")
 class BaseTest(TestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.hy_test_user = UserModel.objects.create_user("hy_test_user", "test_hy@example.com", "123456")
-        self.hy_dev_user = UserModel.objects.create_user("hy_dev_user", "dev_hy@example.com", "123456")
-        self.oauth2_settings.PKCE_REQUIRED = False
-        self.oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES = ["http", "custom-scheme"]
+    factory = RequestFactory()
 
-        self.application = Application(
+    @classmethod
+    def setUpTestData(cls):
+        cls.hy_test_user = UserModel.objects.create_user("hy_test_user", "test_hy@example.com", "123456")
+        cls.hy_dev_user = UserModel.objects.create_user("hy_dev_user", "dev_hy@example.com", "123456")
+
+        cls.application = Application(
             name="Hybrid Test Application",
             redirect_uris=(
                 "http://localhost http://example.com http://example.org custom-scheme://example.com"
             ),
-            user=self.hy_dev_user,
+            user=cls.hy_dev_user,
             client_type=Application.CLIENT_CONFIDENTIAL,
             authorization_grant_type=Application.GRANT_OPENID_HYBRID,
             algorithm=Application.RS256_ALGORITHM,
             client_secret=CLEARTEXT_SECRET,
         )
-        self.application.save()
+        cls.application.save()
 
-    def tearDown(self):
-        self.application.delete()
-        self.hy_test_user.delete()
-        self.hy_dev_user.delete()
+    def setUp(self):
+        self.oauth2_settings.PKCE_REQUIRED = False
+        self.oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES = ["http", "custom-scheme"]
 
 
 @pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)

--- a/tests/test_implicit.py
+++ b/tests/test_implicit.py
@@ -25,23 +25,20 @@ class ResourceView(ProtectedResourceView):
 
 @pytest.mark.usefixtures("oauth2_settings")
 class BaseTest(TestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.test_user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
-        self.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
+    factory = RequestFactory()
 
-        self.application = Application.objects.create(
+    @classmethod
+    def setUpTestData(cls):
+        cls.test_user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
+        cls.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
+
+        cls.application = Application.objects.create(
             name="Test Implicit Application",
             redirect_uris="http://localhost http://example.com http://example.org",
-            user=self.dev_user,
+            user=cls.dev_user,
             client_type=Application.CLIENT_PUBLIC,
             authorization_grant_type=Application.GRANT_IMPLICIT,
         )
-
-    def tearDown(self):
-        self.application.delete()
-        self.test_user.delete()
-        self.dev_user.delete()
 
 
 @pytest.mark.oauth2_settings(presets.DEFAULT_SCOPES_RO)
@@ -276,10 +273,11 @@ class TestImplicitTokenView(BaseTest):
 @pytest.mark.usefixtures("oidc_key")
 @pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)
 class TestOpenIDConnectImplicitFlow(BaseTest):
-    def setUp(self):
-        super().setUp()
-        self.application.algorithm = Application.RS256_ALGORITHM
-        self.application.save()
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.application.algorithm = Application.RS256_ALGORITHM
+        cls.application.save()
 
     def test_id_token_post_auth_allow(self):
         """

--- a/tests/test_introspection_view.py
+++ b/tests/test_introspection_view.py
@@ -27,63 +27,59 @@ class TestTokenIntrospectionViews(TestCase):
     Tests for Authorized Token Introspection Views
     """
 
-    def setUp(self):
-        self.resource_server_user = UserModel.objects.create_user("resource_server", "test@example.com")
-        self.test_user = UserModel.objects.create_user("bar_user", "dev@example.com")
+    @classmethod
+    def setUpTestData(cls):
+        cls.resource_server_user = UserModel.objects.create_user("resource_server", "test@example.com")
+        cls.test_user = UserModel.objects.create_user("bar_user", "dev@example.com")
 
-        self.application = Application.objects.create(
+        cls.application = Application.objects.create(
             name="Test Application",
             redirect_uris="http://localhost http://example.com http://example.org",
-            user=self.test_user,
+            user=cls.test_user,
             client_type=Application.CLIENT_CONFIDENTIAL,
             authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
             client_secret=CLEARTEXT_SECRET,
         )
 
-        self.resource_server_token = AccessToken.objects.create(
-            user=self.resource_server_user,
+        cls.resource_server_token = AccessToken.objects.create(
+            user=cls.resource_server_user,
             token="12345678900",
-            application=self.application,
+            application=cls.application,
             expires=timezone.now() + datetime.timedelta(days=1),
             scope="introspection",
         )
 
-        self.valid_token = AccessToken.objects.create(
-            user=self.test_user,
+        cls.valid_token = AccessToken.objects.create(
+            user=cls.test_user,
             token="12345678901",
-            application=self.application,
+            application=cls.application,
             expires=timezone.now() + datetime.timedelta(days=1),
             scope="read write dolphin",
         )
 
-        self.invalid_token = AccessToken.objects.create(
-            user=self.test_user,
+        cls.invalid_token = AccessToken.objects.create(
+            user=cls.test_user,
             token="12345678902",
-            application=self.application,
+            application=cls.application,
             expires=timezone.now() + datetime.timedelta(days=-1),
             scope="read write dolphin",
         )
 
-        self.token_without_user = AccessToken.objects.create(
+        cls.token_without_user = AccessToken.objects.create(
             user=None,
             token="12345678903",
-            application=self.application,
+            application=cls.application,
             expires=timezone.now() + datetime.timedelta(days=1),
             scope="read write dolphin",
         )
 
-        self.token_without_app = AccessToken.objects.create(
-            user=self.test_user,
+        cls.token_without_app = AccessToken.objects.create(
+            user=cls.test_user,
             token="12345678904",
             application=None,
             expires=timezone.now() + datetime.timedelta(days=1),
             scope="read write dolphin",
         )
-
-    def tearDown(self):
-        AccessToken.objects.all().delete()
-        Application.objects.all().delete()
-        UserModel.objects.all().delete()
 
     def test_view_forbidden(self):
         """

--- a/tests/test_oauth2_backends.py
+++ b/tests/test_oauth2_backends.py
@@ -19,9 +19,11 @@ except ImportError:
 
 @pytest.mark.usefixtures("oauth2_settings")
 class TestOAuthLibCoreBackend(TestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.oauthlib_core = OAuthLibCore()
+    factory = RequestFactory()
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.oauthlib_core = OAuthLibCore()
 
     def test_swappable_server_class(self):
         self.oauth2_settings.OAUTH2_SERVER_CLASS = mock.MagicMock
@@ -60,22 +62,20 @@ AccessTokenModel = get_access_token_model()
 
 @pytest.mark.usefixtures("oauth2_settings")
 class TestOAuthLibCoreBackendErrorHandling(TestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.oauthlib_core = OAuthLibCore()
-        self.user = UserModel.objects.create_user("john", "test@example.com", "123456")
-        self.app = ApplicationModel.objects.create(
+    factory = RequestFactory()
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.oauthlib_core = OAuthLibCore()
+        cls.user = UserModel.objects.create_user("john", "test@example.com", "123456")
+        cls.app = ApplicationModel.objects.create(
             name="app",
             client_id="app_id",
             client_secret="app_secret",
             client_type=ApplicationModel.CLIENT_CONFIDENTIAL,
             authorization_grant_type=ApplicationModel.GRANT_PASSWORD,
-            user=self.user,
+            user=cls.user,
         )
-
-    def tearDown(self):
-        self.user.delete()
-        self.app.delete()
 
     def test_create_token_response_valid(self):
         payload = (
@@ -153,8 +153,7 @@ class TestCustomOAuthLibCoreBackend(TestCase):
         def _get_extra_credentials(self, request):
             return 1
 
-    def setUp(self):
-        self.factory = RequestFactory()
+    factory = RequestFactory()
 
     def test_create_token_response_gets_extra_credentials(self):
         """
@@ -172,9 +171,7 @@ class TestCustomOAuthLibCoreBackend(TestCase):
 
 
 class TestJSONOAuthLibCoreBackend(TestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.oauthlib_core = JSONOAuthLibCore()
+    factory = RequestFactory()
 
     def test_application_json_extract_params(self):
         payload = json.dumps(
@@ -185,16 +182,16 @@ class TestJSONOAuthLibCoreBackend(TestCase):
             }
         )
         request = self.factory.post("/o/token/", payload, content_type="application/json")
+        oauthlib_core = JSONOAuthLibCore()
 
-        uri, http_method, body, headers = self.oauthlib_core._extract_params(request)
+        uri, http_method, body, headers = oauthlib_core._extract_params(request)
         self.assertIn("grant_type=password", body)
         self.assertIn("username=john", body)
         self.assertIn("password=123456", body)
 
 
 class TestOAuthLibCore(TestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
+    factory = RequestFactory()
 
     def test_validate_authorization_request_unsafe_query(self):
         auth_headers = {

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -477,11 +477,12 @@ class TestOAuth2ValidatorErrorResourceToken(TestCase):
     is unsuccessful.
     """
 
-    def setUp(self):
-        self.token = "test_token"
-        self.introspection_url = "http://example.com/token/introspection/"
-        self.introspection_token = "test_introspection_token"
-        self.validator = OAuth2Validator()
+    @classmethod
+    def setUpTestData(cls):
+        cls.token = "test_token"
+        cls.introspection_url = "http://example.com/token/introspection/"
+        cls.introspection_token = "test_introspection_token"
+        cls.validator = OAuth2Validator()
 
     def test_response_when_auth_server_response_return_404(self):
         with self.assertLogs(logger="oauth2_provider") as mock_log:

--- a/tests/test_password.py
+++ b/tests/test_password.py
@@ -25,23 +25,20 @@ class ResourceView(ProtectedResourceView):
 
 @pytest.mark.usefixtures("oauth2_settings")
 class BaseTest(TestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.test_user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
-        self.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
+    factory = RequestFactory()
 
-        self.application = Application.objects.create(
+    @classmethod
+    def setUpTestData(cls):
+        cls.test_user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
+        cls.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
+
+        cls.application = Application.objects.create(
             name="Test Password Application",
-            user=self.dev_user,
+            user=cls.dev_user,
             client_type=Application.CLIENT_PUBLIC,
             authorization_grant_type=Application.GRANT_PASSWORD,
             client_secret=CLEARTEXT_SECRET,
         )
-
-    def tearDown(self):
-        self.application.delete()
-        self.test_user.delete()
-        self.dev_user.delete()
 
 
 class TestPasswordTokenView(BaseTest):

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -130,24 +130,25 @@ urlpatterns = [
 @pytest.mark.usefixtures("oauth2_settings")
 @pytest.mark.oauth2_settings(presets.REST_FRAMEWORK_SCOPES)
 class TestOAuth2Authentication(TestCase):
-    def setUp(self):
-        self.test_user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
-        self.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
+    @classmethod
+    def setUpTestData(cls):
+        cls.test_user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
+        cls.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
 
-        self.application = Application.objects.create(
+        cls.application = Application.objects.create(
             name="Test Application",
             redirect_uris="http://localhost http://example.com http://example.org",
-            user=self.dev_user,
+            user=cls.dev_user,
             client_type=Application.CLIENT_CONFIDENTIAL,
             authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
         )
 
-        self.access_token = AccessToken.objects.create(
-            user=self.test_user,
+        cls.access_token = AccessToken.objects.create(
+            user=cls.test_user,
             scope="read write",
             expires=timezone.now() + timedelta(seconds=300),
             token="secret-access-token-key",
-            application=self.application,
+            application=cls.application,
         )
 
     def _create_authorization_header(self, token):

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -58,24 +58,21 @@ SCOPE_SETTINGS = {
 @pytest.mark.usefixtures("oauth2_settings")
 @pytest.mark.oauth2_settings(SCOPE_SETTINGS)
 class BaseTest(TestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.test_user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
-        self.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
+    factory = RequestFactory()
 
-        self.application = Application.objects.create(
+    @classmethod
+    def setUpTestData(cls):
+        cls.test_user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
+        cls.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
+
+        cls.application = Application.objects.create(
             name="Test Application",
             redirect_uris="http://localhost http://example.com http://example.org",
-            user=self.dev_user,
+            user=cls.dev_user,
             client_type=Application.CLIENT_CONFIDENTIAL,
             authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
             client_secret=CLEARTEXT_SECRET,
         )
-
-    def tearDown(self):
-        self.application.delete()
-        self.test_user.delete()
-        self.dev_user.delete()
 
 
 class TestScopesSave(BaseTest):

--- a/tests/test_token_endpoint_cors.py
+++ b/tests/test_token_endpoint_cors.py
@@ -31,30 +31,26 @@ class TestTokenEndpointCors(TestCase):
     The objective is: http request 'Origin' header should be passed to OAuthLib
     """
 
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.test_user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
-        self.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
+    factory = RequestFactory()
 
-        self.oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES = ["https"]
-        self.oauth2_settings.PKCE_REQUIRED = False
+    @classmethod
+    def setUpTestData(cls):
+        cls.test_user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
+        cls.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
 
-        self.application = Application.objects.create(
+        cls.application = Application.objects.create(
             name="Test Application",
             redirect_uris=CLIENT_URI,
-            user=self.dev_user,
+            user=cls.dev_user,
             client_type=Application.CLIENT_CONFIDENTIAL,
             authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
             client_secret=CLEARTEXT_SECRET,
             allowed_origins=CLIENT_URI,
         )
 
+    def setUp(self):
         self.oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES = ["https"]
-
-    def tearDown(self):
-        self.application.delete()
-        self.test_user.delete()
-        self.dev_user.delete()
+        self.oauth2_settings.PKCE_REQUIRED = False
 
     def test_valid_origin_with_https(self):
         """

--- a/tests/test_token_revocation.py
+++ b/tests/test_token_revocation.py
@@ -17,24 +17,21 @@ CLEARTEXT_SECRET = "1234567890abcdefghijklmnopqrstuvwxyz"
 
 
 class BaseTest(TestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.test_user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
-        self.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
+    factory = RequestFactory()
 
-        self.application = Application.objects.create(
+    @classmethod
+    def setUpTestData(cls):
+        cls.test_user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
+        cls.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
+
+        cls.application = Application.objects.create(
             name="Test Application",
             redirect_uris="http://localhost http://example.com http://example.org",
-            user=self.dev_user,
+            user=cls.dev_user,
             client_type=Application.CLIENT_CONFIDENTIAL,
             authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
             client_secret=CLEARTEXT_SECRET,
         )
-
-    def tearDown(self):
-        self.application.delete()
-        self.test_user.delete()
-        self.dev_user.delete()
 
 
 class TestRevocationView(BaseTest):

--- a/tests/test_token_view.py
+++ b/tests/test_token_view.py
@@ -18,21 +18,18 @@ class TestAuthorizedTokenViews(TestCase):
     TestCase superclass for Authorized Token Views" Test Cases
     """
 
-    def setUp(self):
-        self.foo_user = UserModel.objects.create_user("foo_user", "test@example.com", "123456")
-        self.bar_user = UserModel.objects.create_user("bar_user", "dev@example.com", "123456")
+    @classmethod
+    def setUpTestData(cls):
+        cls.foo_user = UserModel.objects.create_user("foo_user", "test@example.com", "123456")
+        cls.bar_user = UserModel.objects.create_user("bar_user", "dev@example.com", "123456")
 
-        self.application = Application.objects.create(
+        cls.application = Application.objects.create(
             name="Test Application",
             redirect_uris="http://localhost http://example.com http://example.org",
-            user=self.bar_user,
+            user=cls.bar_user,
             client_type=Application.CLIENT_CONFIDENTIAL,
             authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
         )
-
-    def tearDown(self):
-        self.foo_user.delete()
-        self.bar_user.delete()
 
 
 class TestAuthorizedTokenListView(TestAuthorizedTokenViews):


### PR DESCRIPTION
## Description of the Change

Speed up the test suite to be about twice as fast, using these techniques:

1. Move model creation into `setUpTestData()`, so it runs only once per test case. See [my post](https://adamj.eu/tech/2021/04/12/how-to-convert-a-testcase-from-setup-to-setuptestdata/).
2. Remove `tearDown()` methods that removed model instances. These were always unnecessary as Django resets the database for you.
3. Move immutable `RequestFactory`s to class-level variables.

Measuring on the Python 3.12 and Django 5.0 environment (added in #1350), I got 207s before these changes and 105s afterwards, approximately twice as fast.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
