### PR TITLE
Move signal import to django.core

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Adam Johnson
 Adam Zahradník
 Adheeth P Praveen
 Alan Crosswell
+Alan Rominger
 Alejandro Mantecon Guillen
 Aleksander Vaskevich
 Alessandro De Angelis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1284 Allow to logout with no id_token_hint even if the browser session already expired
 * #1296 Added reverse function in migration 0006_alter_application_client_secret
 * #1336 Fix encapsulation for Redirect URI scheme validation
+* #1357 Move import of setting_changed signal from test to django core modules
 
 ### Removed
 * #1350 Remove support for Python 3.7 and Django 2.2

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -18,8 +18,8 @@ back to the defaults.
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.http import HttpRequest
 from django.core.signals import setting_changed
+from django.http import HttpRequest
 from django.urls import reverse
 from django.utils.module_loading import import_string
 from oauthlib.common import Request

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -19,7 +19,7 @@ back to the defaults.
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
-from django.test.signals import setting_changed
+from django.core.signals import setting_changed
 from django.urls import reverse
 from django.utils.module_loading import import_string
 from oauthlib.common import Request


### PR DESCRIPTION
## Description of the Change

Hi :wave: , I believe this is causing us a problem, but I lack technical rigor to be able to explain it fully. By applying this change under certain circumstances, I seem to avoid a core dump that happens as uWSGI recycles workers when it is running in the default prefork mode. The most relevant description of the series of events is this comment: https://github.com/unbit/uwsgi/issues/1969#issuecomment-462252471

Here, I just wish to present this as an improvement to follow best practice. In the `django.test.signals` module, you can see it imports from this modification with no modifications.

https://github.com/django/django/blob/main/django/test/signals.py

However, somewhat obviously... if you import this test _module_, you will also register all the test signal connections. Now, that _shouldn't_ do anything because the `setting_changed` signal is documented to only fire when running tests. However, it also pulls in a lot of _other_ imports which just aren't needed, and as this happens in settings, it triggers fairly early in app load order.

This argument also applies to 1 import in DRF, which I also hope to submit a patch for. I'm still working out final testing on my side, so consider this a draft as of opening.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
