### PR TITLE
fix: prompt=none shows a login screen

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Allisson Azevedo
 Andrea Greco
 Andrej Zbín
 Andrew Chen Wang
+Andrew Zickler
 Antoine Laurent
 Anvesh Agarwal
 Aristóbulo Meneses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1311 Add option to disable client_secret hashing to allow verifying JWTs' signatures.
 * #1337 Gracefully handle expired or deleted refresh tokens, in `validate_user`.
 * #1350 Support Python 3.12 and Django 5.0
-* #1249 Add code_challenge_methods_supported property to auto discovery informations
-  per [RFC 8414 section 2](https://www.rfc-editor.org/rfc/rfc8414.html#page-7)
+* #1249 Add code_challenge_methods_supported property to auto discovery informations, per [RFC 8414 section 2](https://www.rfc-editor.org/rfc/rfc8414.html#page-7)
+
 
 ### Fixed
 * #1322 Instructions in documentation on how to create a code challenge and code verifier
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1296 Added reverse function in migration 0006_alter_application_client_secret
 * #1336 Fix encapsulation for Redirect URI scheme validation
 * #1357 Move import of setting_changed signal from test to django core modules
+* #1268 fix prompt=none redirects to login screen
 
 ### Removed
 * #1350 Remove support for Python 3.7 and Django 2.2

--- a/tests/app/idp/idp/oauth.py
+++ b/tests/app/idp/idp/oauth.py
@@ -1,0 +1,40 @@
+from django.conf import settings
+from django.contrib.auth.middleware import AuthenticationMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
+
+from oauth2_provider.oauth2_validators import OAuth2Validator
+
+
+# get_response is required for middlware, it doesn't need to do anything
+# the way we're using it, so we just use a lambda that returns None
+def get_response():
+    None
+
+
+class CustomOAuth2Validator(OAuth2Validator):
+    def validate_silent_login(self, request) -> None:
+        # request is an OAuthLib.common.Request and doesn't have the session
+        # or user of the django request. We will emulate the session and auth
+        # middleware here, since that is what the idp is using for auth. You
+        # may need to modify this if you are using a different session
+        # middleware or auth backend.
+
+        session_cookie_name = settings.SESSION_COOKIE_NAME
+        HTTP_COOKIE = request.headers.get("HTTP_COOKIE")
+        COOKIES = HTTP_COOKIE.split("; ")
+        for cookie in COOKIES:
+            cookie_name, cookie_value = cookie.split("=")
+            if cookie.startswith(session_cookie_name):
+                break
+        session_middleware = SessionMiddleware(get_response)
+        session = session_middleware.SessionStore(cookie_value)
+        # add session to request for compatibility with django.contrib.auth
+        request.session = session
+
+        # call the auth middleware to set request.user
+        auth_middleware = AuthenticationMiddleware(get_response)
+        auth_middleware.process_request(request)
+        return request.user.is_authenticated
+
+    def validate_silent_authorization(self, request) -> None:
+        return True

--- a/tests/app/idp/idp/settings.py
+++ b/tests/app/idp/idp/settings.py
@@ -129,6 +129,7 @@ STATIC_URL = "static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 OAUTH2_PROVIDER = {
+    "OAUTH2_VALIDATOR_CLASS": "idp.oauth.CustomOAuth2Validator",
     "OIDC_ENABLED": True,
     "OIDC_RP_INITIATED_LOGOUT_ENABLED": True,
     # this key is just for out test app, you should never store a key like this in a production environment.

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -572,8 +572,6 @@ class TestOIDCAuthorizationCodeView(BaseTest):
         self.assertIn("scope=openid", next)
         self.assertIn("redirect_uri=http%3A%2F%2Fexample.org", next)
 
-
-
     def test_id_token_skip_authorization_completely(self):
         """
         If application.skip_authorization = True, should skip the authorization page.

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -545,6 +545,35 @@ class TestAuthorizationCodeView(BaseTest):
 
 @pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)
 class TestOIDCAuthorizationCodeView(BaseTest):
+    def test_login(self):
+        """
+        Test login page is rendered if user is not authenticated
+        """
+        self.oauth2_settings.PKCE_REQUIRED = False
+
+        query_data = {
+            "client_id": self.application.client_id,
+            "response_type": "code",
+            "state": "random_state_string",
+            "scope": "openid",
+            "redirect_uri": "http://example.org",
+        }
+        path = reverse("oauth2_provider:authorize")
+        response = self.client.get(path, data=query_data)
+        # The authorization view redirects to the login page with the
+        self.assertEqual(response.status_code, 302)
+        scheme, netloc, path, params, query, fragment = urlparse(response["Location"])
+        self.assertEqual(path, settings.LOGIN_URL)
+        parsed_query = parse_qs(query)
+        next = parsed_query["next"][0]
+        self.assertIn(f"client_id={self.application.client_id}", next)
+        self.assertIn("response_type=code", next)
+        self.assertIn("state=random_state_string", next)
+        self.assertIn("scope=openid", next)
+        self.assertIn("redirect_uri=http%3A%2F%2Fexample.org", next)
+
+
+
     def test_id_token_skip_authorization_completely(self):
         """
         If application.skip_authorization = True, should skip the authorization page.
@@ -644,6 +673,33 @@ class TestOIDCAuthorizationCodeView(BaseTest):
         self.assertIn(f"client_id={self.application.client_id}", next)
 
         self.assertNotIn("prompt=login", next)
+
+    def test_prompt_none_unauthorized(self):
+        """
+        Test response for redirect when supplied with prompt: none
+
+        Should redirect to redirect_uri with an error of login_required
+        """
+        self.oauth2_settings.PKCE_REQUIRED = False
+
+        query_data = {
+            "client_id": self.application.client_id,
+            "response_type": "code",
+            "state": "random_state_string",
+            "scope": "read write",
+            "redirect_uri": "http://example.org",
+            "prompt": "none",
+        }
+
+        response = self.client.get(reverse("oauth2_provider:authorize"), data=query_data)
+
+        self.assertEqual(response.status_code, 302)
+
+        scheme, netloc, path, params, query, fragment = urlparse(response["Location"])
+        parsed_query = parse_qs(query)
+
+        self.assertIn("login_required", parsed_query["error"])
+        self.assertIn("random_state_string", parsed_query["state"])
 
 
 class BaseAuthorizationCodeTokenView(BaseTest):


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1268

## Description of the Change

Fix bug preventing support for Silent Authentication. If an unauthorized request to `AuthorizationView` with a query parameter that contains `prompt=none` happens, then we will redirect with an error code of `login_required` otherwise everything will proceed as before. 

See https://auth0.com/docs/authenticate/login/configure-silent-authentication#error-responses
and https://openid.net/specs/openid-connect-core-1_0.html#AuthError

fully supporting prompt=none will require implementing validate_silent_login in the validator. this doesn't implement that, but will allow people to implement it if they want until we can implement a good implementation for DOT. 

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
