### PR TITLE
Add code_challenge_methods_supported property to OIDC auto discovery

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,6 +52,7 @@ Egor Poderiagin
 Emanuele Palazzetti
 Federico Dolce
 Frederico Vieira
+Gaël Utard
 Hasan Ramezani
 Hiroki Kiyohara
 Hossein Shakiba

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1311 Add option to disable client_secret hashing to allow verifying JWTs' signatures.
 * #1337 Gracefully handle expired or deleted refresh tokens, in `validate_user`.
 * #1350 Support Python 3.12 and Django 5.0
+* #1249 Add code_challenge_methods_supported property to auto discovery informations
+  per [RFC 8414 section 2](https://www.rfc-editor.org/rfc/rfc8414.html#page-7)
 
 ### Fixed
 * #1322 Instructions in documentation on how to create a code challenge and code verifier

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -26,6 +26,7 @@ from ..exceptions import (
 from ..forms import ConfirmLogoutForm
 from ..http import OAuth2ResponseRedirect
 from ..models import (
+    AbstractGrant,
     get_access_token_model,
     get_application_model,
     get_id_token_model,
@@ -96,6 +97,7 @@ class ConnectDiscoveryInfoView(OIDCOnlyMixin, View):
             "token_endpoint_auth_methods_supported": (
                 oauth2_settings.OIDC_TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED
             ),
+            "code_challenge_methods_supported": [key for key, _ in AbstractGrant.CODE_CHALLENGE_METHODS],
             "claims_supported": oidc_claims,
         }
         if oauth2_settings.OIDC_RP_INITIATED_LOGOUT_ENABLED:

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -48,6 +48,7 @@ class TestConnectDiscoveryInfoView(TestCase):
             "subject_types_supported": ["public"],
             "id_token_signing_alg_values_supported": ["RS256", "HS256"],
             "token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"],
+            "code_challenge_methods_supported": ["plain", "S256"],
             "claims_supported": ["sub"],
         }
         response = self.client.get("/o/.well-known/openid-configuration")
@@ -74,6 +75,7 @@ class TestConnectDiscoveryInfoView(TestCase):
             "subject_types_supported": ["public"],
             "id_token_signing_alg_values_supported": ["RS256", "HS256"],
             "token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"],
+            "code_challenge_methods_supported": ["plain", "S256"],
             "claims_supported": ["sub"],
         }
         response = self.client.get("/o/.well-known/openid-configuration/")
@@ -100,6 +102,7 @@ class TestConnectDiscoveryInfoView(TestCase):
             "subject_types_supported": ["public"],
             "id_token_signing_alg_values_supported": ["RS256", "HS256"],
             "token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"],
+            "code_challenge_methods_supported": ["plain", "S256"],
             "claims_supported": ["sub"],
             "end_session_endpoint": f"{base}/logout/",
         }
@@ -133,6 +136,7 @@ class TestConnectDiscoveryInfoView(TestCase):
             "subject_types_supported": ["public"],
             "id_token_signing_alg_values_supported": ["RS256", "HS256"],
             "token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"],
+            "code_challenge_methods_supported": ["plain", "S256"],
             "claims_supported": ["sub"],
         }
         response = self.client.get(reverse("oauth2_provider:oidc-connect-discovery-info"))


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1249

## Description of the Change

Some OIDC clients require code_challenge_methods_supported to be present in auto discovery information. The PR adds this property to ConnectDiscoveryInfoView.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
