### PR TITLE
Allow the user to add the application fields to the application form

### DIFF
--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -62,7 +62,7 @@ DEFAULTS = {
     "ID_TOKEN_MODEL": ID_TOKEN_MODEL,
     "GRANT_MODEL": GRANT_MODEL,
     "REFRESH_TOKEN_MODEL": REFRESH_TOKEN_MODEL,
-    "APPLICATION_FIELDS":APPLICATION_FIELDS,
+    "APPLICATION_FIELDS": APPLICATION_FIELDS,
     "APPLICATION_ADMIN_CLASS": "oauth2_provider.admin.ApplicationAdmin",
     "ACCESS_TOKEN_ADMIN_CLASS": "oauth2_provider.admin.AccessTokenAdmin",
     "GRANT_ADMIN_CLASS": "oauth2_provider.admin.GrantAdmin",

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -18,8 +18,8 @@ back to the defaults.
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.core.signals import setting_changed
 from django.http import HttpRequest
+from django.test.signals import setting_changed
 from django.urls import reverse
 from django.utils.module_loading import import_string
 from oauthlib.common import Request
@@ -32,6 +32,7 @@ ACCESS_TOKEN_MODEL = getattr(settings, "OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL", "oa
 ID_TOKEN_MODEL = getattr(settings, "OAUTH2_PROVIDER_ID_TOKEN_MODEL", "oauth2_provider.IDToken")
 GRANT_MODEL = getattr(settings, "OAUTH2_PROVIDER_GRANT_MODEL", "oauth2_provider.Grant")
 REFRESH_TOKEN_MODEL = getattr(settings, "OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL", "oauth2_provider.RefreshToken")
+APPLICATION_FIELDS = getattr(settings, "OAUTH2_PROVIDER_APPLICATION_FIELDS", None)
 
 DEFAULTS = {
     "CLIENT_ID_GENERATOR_CLASS": "oauth2_provider.generators.ClientIdGenerator",
@@ -61,6 +62,7 @@ DEFAULTS = {
     "ID_TOKEN_MODEL": ID_TOKEN_MODEL,
     "GRANT_MODEL": GRANT_MODEL,
     "REFRESH_TOKEN_MODEL": REFRESH_TOKEN_MODEL,
+    "APPLICATION_FIELDS":APPLICATION_FIELDS,
     "APPLICATION_ADMIN_CLASS": "oauth2_provider.admin.ApplicationAdmin",
     "ACCESS_TOKEN_ADMIN_CLASS": "oauth2_provider.admin.AccessTokenAdmin",
     "GRANT_ADMIN_CLASS": "oauth2_provider.admin.GrantAdmin",
@@ -68,7 +70,6 @@ DEFAULTS = {
     "REFRESH_TOKEN_ADMIN_CLASS": "oauth2_provider.admin.RefreshTokenAdmin",
     "REQUEST_APPROVAL_PROMPT": "force",
     "ALLOWED_REDIRECT_URI_SCHEMES": ["http", "https"],
-    "ALLOWED_SCHEMES": ["https"],
     "OIDC_ENABLED": False,
     "OIDC_ISS_ENDPOINT": "",
     "OIDC_USERINFO_ENDPOINT": "",
@@ -103,7 +104,7 @@ DEFAULTS = {
     "RESOURCE_SERVER_INTROSPECTION_CREDENTIALS": None,
     "RESOURCE_SERVER_TOKEN_CACHING_SECONDS": 36000,
     # Whether or not PKCE is required
-    "PKCE_REQUIRED": True,
+    "PKCE_REQUIRED": False,
     # Whether to re-create OAuthlibCore on every request.
     # Should only be required in testing.
     "ALWAYS_RELOAD_OAUTHLIB_CORE": False,
@@ -295,7 +296,7 @@ class OAuth2ProviderSettings:
         else:
             raise TypeError("request must be a django or oauthlib request: got %r" % request)
         abs_url = django_request.build_absolute_uri(reverse("oauth2_provider:oidc-connect-discovery-info"))
-        return abs_url[: -len("/.well-known/openid-configuration")]
+        return abs_url[: -len("/.well-known/openid-configuration/")]
 
 
 oauth2_settings = OAuth2ProviderSettings(USER_SETTINGS, DEFAULTS, IMPORT_STRINGS, MANDATORY)
@@ -305,6 +306,7 @@ def reload_oauth2_settings(*args, **kwargs):
     setting = kwargs["setting"]
     if setting == "OAUTH2_PROVIDER":
         oauth2_settings.reload()
+        print(f"==>> oauth2_settings: {oauth2_settings}")
 
 
 setting_changed.connect(reload_oauth2_settings)

--- a/oauth2_provider/views/application.py
+++ b/oauth2_provider/views/application.py
@@ -6,6 +6,7 @@ from django.views.generic import CreateView, DeleteView, DetailView, ListView, U
 from ..models import get_application_model
 from ..settings import oauth2_settings
 
+
 class ApplicationOwnerIsUserMixin(LoginRequiredMixin):
     """
     This mixin is used to provide an Application queryset filtered by the current request.user.
@@ -30,7 +31,8 @@ class ApplicationRegistration(LoginRequiredMixin, CreateView):
         """
         return modelform_factory(
             get_application_model(),
-            fields = oauth2_settings.APPLICATION_FIELDS or (
+            fields=oauth2_settings.APPLICATION_FIELDS
+            or (
                 "name",
                 "client_id",
                 "client_secret",
@@ -88,7 +90,8 @@ class ApplicationUpdate(ApplicationOwnerIsUserMixin, UpdateView):
         """
         return modelform_factory(
             get_application_model(),
-            fields = oauth2_settings.APPLICATION_FIELDS or (
+            fields=oauth2_settings.APPLICATION_FIELDS
+            or (
                 "name",
                 "client_id",
                 "client_secret",

--- a/oauth2_provider/views/application.py
+++ b/oauth2_provider/views/application.py
@@ -4,7 +4,7 @@ from django.urls import reverse_lazy
 from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView
 
 from ..models import get_application_model
-
+from ..settings import oauth2_settings
 
 class ApplicationOwnerIsUserMixin(LoginRequiredMixin):
     """
@@ -30,16 +30,13 @@ class ApplicationRegistration(LoginRequiredMixin, CreateView):
         """
         return modelform_factory(
             get_application_model(),
-            fields=(
+            fields = oauth2_settings.APPLICATION_FIELDS or (
                 "name",
                 "client_id",
                 "client_secret",
-                "hash_client_secret",
                 "client_type",
                 "authorization_grant_type",
                 "redirect_uris",
-                "post_logout_redirect_uris",
-                "allowed_origins",
                 "algorithm",
             ),
         )
@@ -91,16 +88,13 @@ class ApplicationUpdate(ApplicationOwnerIsUserMixin, UpdateView):
         """
         return modelform_factory(
             get_application_model(),
-            fields=(
+            fields = oauth2_settings.APPLICATION_FIELDS or (
                 "name",
                 "client_id",
                 "client_secret",
-                "hash_client_secret",
                 "client_type",
                 "authorization_grant_type",
                 "redirect_uris",
-                "post_logout_redirect_uris",
-                "allowed_origins",
                 "algorithm",
             ),
         )


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #
Allow the user to add the application fields to the application form
## Description of the Change
Allow the user to add the application fields to the application form
## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
