### PR TITLE
Don't access oauth2_settings if OAuthLibCore server parameter is prov…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Bart Merenda
 Bas van Oostveen
 Brian Helba
 Carl Schwan
+Clayton Singh
 Daniel Golding
 Daniel 'Vector' Kerr
 Darrel O'Pry

--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -22,10 +22,12 @@ class OAuthLibCore:
         """
         :params server: An instance of oauthlib.oauth2.Server class
         """
-        validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
-        validator = validator_class()
-        server_kwargs = oauth2_settings.server_kwargs
-        self.server = server or oauth2_settings.OAUTH2_SERVER_CLASS(validator, **server_kwargs)
+        if not server:
+            validator_class = oauth2_settings.OAUTH2_VALIDATOR_CLASS
+            validator = validator_class()
+            server_kwargs = oauth2_settings.server_kwargs
+            server = oauth2_settings.OAUTH2_SERVER_CLASS(validator, **server_kwargs)
+        self.server = server
 
     def _get_escaped_full_path(self, request):
         """


### PR DESCRIPTION
## Description of the Change
Dont access oauth2_settings if server parameter is provided

## Checklist
- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
