### PR TITLE
docs: fix a tiny typo in method docstring

### DIFF
--- a/oauth2_provider/views/token.py
+++ b/oauth2_provider/views/token.py
@@ -16,7 +16,7 @@ class AuthorizedTokensListView(LoginRequiredMixin, ListView):
 
     def get_queryset(self):
         """
-        Show only user"s tokens
+        Show only user's tokens
         """
         return super().get_queryset().select_related("application").filter(user=self.request.user)
 


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->

## Description of the Change

Hi, this is a just small typo fix in one method docstring.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
