### PR TITLE
Update url for RP initiated logout

### DIFF
--- a/docs/oidc.rst
+++ b/docs/oidc.rst
@@ -430,5 +430,5 @@ customize the details included in the response as described above.
 RPInitiatedLogoutView
 ~~~~~~~~~~~~~~~~~~~~~
 
-Available at ``/o/rp-initiated-logout/``, this view allows a :term:`Client` (Relying Party) to request that a :term:`Resource Owner`
+Available at ``/o/logout/``, this view allows a :term:`Client` (Relying Party) to request that a :term:`Resource Owner`
 is logged out at the :term:`Authorization Server` (OpenID Provider).


### PR DESCRIPTION
According to [urls.py](https://github.com/jazzband/django-oauth-toolkit/blob/master/oauth2_provider/urls.py#L45), the url should be /logout

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ ] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
