### PR TITLE
Add localhost to allowed loopback addresses

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -56,7 +56,7 @@ A list of schemes that the ``redirect_uri`` field will be validated against.
 Setting this to ``["https"]`` only in production is strongly recommended.
 
 For Native Apps the ``http`` scheme can be safely used with loopback addresses in the
-Application (``[::1]`` or ``127.0.0.1``). In this case the ``redirect_uri`` can be
+Application (``[::1]`` or ``127.0.0.1`` or ``localhost``). In this case the ``redirect_uri`` can be
 configured without explicit port specification, so that the Application accepts randomly
 assigned ports.
 

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -778,7 +778,7 @@ def redirect_to_uri_allowed(uri, allowed_uris):
 
         allowed_uri_is_loopback = (
             parsed_allowed_uri.scheme == "http"
-            and parsed_allowed_uri.hostname in ["127.0.0.1", "::1"]
+            and parsed_allowed_uri.hostname in ["127.0.0.1", "::1", "localhost"]
             and parsed_allowed_uri.port is None
         )
         if (

--- a/tests/test_oauth2_backends.py
+++ b/tests/test_oauth2_backends.py
@@ -205,9 +205,9 @@ class TestOAuthLibCore(TestCase):
 
 @pytest.mark.parametrize(
     "uri, expected_result",
-    # localhost is _not_ a loopback URI
+
     [
-        ("http://localhost:3456", False),
+        ("http://localhost:3456", True), # localhost is supported
         # only http scheme is supported for loopback URIs
         ("https://127.0.0.1:3456", False),
         ("http://127.0.0.1:3456", True),
@@ -216,8 +216,18 @@ class TestOAuthLibCore(TestCase):
     ],
 )
 def test_uri_loopback_redirect_check(uri, expected_result):
-    allowed_uris = ["http://127.0.0.1", "http://[::1]"]
+    allowed_uris = ["http://127.0.0.1", "http://[::1]", "http://localhost"]
     if expected_result:
         assert redirect_to_uri_allowed(uri, allowed_uris)
     else:
         assert not redirect_to_uri_allowed(uri, allowed_uris)
+
+class TestLocalhostRedirectURI(TestCase):
+    def test_localhost_redirect_uri(self):
+        allowed_uris = ["http://127.0.0.1", "http://[::1]", "http://localhost"]
+        
+        valid_localhost_uri = "http://localhost:8000/callback"
+        invalid_localhost_uri_https = "https://localhost:8000/callback"
+
+        self.assertTrue(redirect_to_uri_allowed(valid_localhost_uri, allowed_uris))
+        self.assertFalse(redirect_to_uri_allowed(invalid_localhost_uri_https, allowed_uris))

--- a/tests/test_oauth2_backends.py
+++ b/tests/test_oauth2_backends.py
@@ -205,9 +205,8 @@ class TestOAuthLibCore(TestCase):
 
 @pytest.mark.parametrize(
     "uri, expected_result",
-
     [
-        ("http://localhost:3456", True), # localhost is supported
+        ("http://localhost:3456", True),  # localhost is supported
         # only http scheme is supported for loopback URIs
         ("https://127.0.0.1:3456", False),
         ("http://127.0.0.1:3456", True),

--- a/tests/test_oauth2_backends.py
+++ b/tests/test_oauth2_backends.py
@@ -221,13 +221,3 @@ def test_uri_loopback_redirect_check(uri, expected_result):
         assert redirect_to_uri_allowed(uri, allowed_uris)
     else:
         assert not redirect_to_uri_allowed(uri, allowed_uris)
-
-class TestLocalhostRedirectURI(TestCase):
-    def test_localhost_redirect_uri(self):
-        allowed_uris = ["http://127.0.0.1", "http://[::1]", "http://localhost"]
-        
-        valid_localhost_uri = "http://localhost:8000/callback"
-        invalid_localhost_uri_https = "https://localhost:8000/callback"
-
-        self.assertTrue(redirect_to_uri_allowed(valid_localhost_uri, allowed_uris))
-        self.assertFalse(redirect_to_uri_allowed(invalid_localhost_uri_https, allowed_uris))

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -17,6 +17,7 @@ class TestValidators(TestCase):
             "https://1.1.1.1",
             "https://127.0.0.1",
             "https://255.255.255.255",
+            "http://localhost",
         ]
         for uri in good_uris:
             # Check ValidationError not thrown
@@ -31,6 +32,7 @@ class TestValidators(TestCase):
             "https://example.com",
             "HTTPS://example.com",
             "git+ssh://example.com",
+            "http://localhost",
         ]
         for uri in good_uris:
             # Check ValidationError not thrown

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -8,7 +8,7 @@ from oauth2_provider.validators import AllowedURIValidator, RedirectURIValidator
 @pytest.mark.usefixtures("oauth2_settings")
 class TestValidators(TestCase):
     def test_validate_good_uris(self):
-        validator = RedirectURIValidator(allowed_schemes=["https"])
+        validator = RedirectURIValidator(allowed_schemes=["https", "http"])
         good_uris = [
             "https://example.com/",
             "https://example.org/?key=val",
@@ -24,7 +24,7 @@ class TestValidators(TestCase):
             validator(uri)
 
     def test_validate_custom_uri_scheme(self):
-        validator = RedirectURIValidator(allowed_schemes=["my-scheme", "https", "git+ssh"])
+        validator = RedirectURIValidator(allowed_schemes=["my-scheme", "https", "git+ssh", "http"])
         good_uris = [
             "my-scheme://example.com",
             "my-scheme://example",


### PR DESCRIPTION
Fixes #1416 

### Description

This pull request adds `localhost` to the list of allowed loopback addresses for redirect URIs in the `django-oauth-toolkit` library.

### Changes Made

1. Updated validation logic to include `localhost` as a valid loopback address.
2. Modified tests to validate `localhost` as a valid URI.
3. Verified that fixture data includes `localhost` entries.

### Rationale

This change improves usability by allowing the use of `localhost` in development environments, aligning with common practices.

### Related Issue

[Add localhost to Allowed Loopback Addresses for Redirect URIs](https://github.com/jazzband/django-oauth-toolkit/issues/1416)
