### PR TITLE
1421 missing import in documentation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,6 +56,7 @@ Florian Demmer
 Frederico Vieira
 Gaël Utard
 Glauco Junior
+Giovanni Giampauli
 Hasan Ramezani
 Hiroki Kiyohara
 Hossein Shakiba

--- a/docs/tutorial/tutorial_05.rst
+++ b/docs/tutorial/tutorial_05.rst
@@ -65,6 +65,7 @@ Now add a new file to your app to add Celery: :file:`tutorial/celery.py`:
     import os
 
     from celery import Celery
+    from django.conf import settings
 
     # Set the default Django settings module for the 'celery' program.
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tutorial.settings')


### PR DESCRIPTION
**Fixes #1421**

## Description of the Change

The code snippet provided in the documentation needs an additional import to function correctly. Without this import, the code does not raise any errors, but it fails to discover `@shared_task`s in other files. This PR adds the necessary import statement.

**Link to Documentation:** [Django OAuth Toolkit Tutorial - Step 5](https://django-oauth-toolkit.readthedocs.io/en/latest/tutorial/tutorial_05.html)

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] Unit-test added
- [x] Documentation updated
- [ ] `CHANGELOG.md` updated (only for user-relevant changes)
- [x] Author name in `AUTHORS`