### PR TITLE
chore: fix code spell errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,11 +29,11 @@ repos:
     rev: v0.9.1
     hooks:
       - id: sphinx-lint
-  # Configuration for codespell is in pyproject.toml
-  # - repo: https://github.com/codespell-project/codespell
-  #   rev: v2.3.0
-  #   hooks:
-  #   - id: codespell
-  #     exclude: (package-lock.json|/locale/)
-  #     additional_dependencies:
-  #     - tomli
+#  Configuration for codespell is in pyproject.toml
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+    - id: codespell
+      exclude: (package-lock.json|/locale/)
+      additional_dependencies:
+      - tomli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,7 +206,7 @@ This is a major release with **BREAKING** changes. Please make sure to review th
 
 ## [1.6.0] 2021-12-19
 ### Added
-* #949 Provide django.contrib.auth.authenticate() with a `request` for compatibiity with more backends (like django-axes).
+* #949 Provide django.contrib.auth.authenticate() with a `request` for compatibility with more backends (like django-axes).
 * #968, #1039 Add support for Django 3.2 and 4.0.
 * #953 Allow loopback redirect URIs using random ports as described in [RFC8252 section 7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3).
 * #972 Add Farsi/fa language support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ exclude = '''
 '''
 
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-# [tool.codespell]
-# skip = '.git,package-lock.json,locale'
-# check-hidden = true
-# ignore-regex = '.*pragma: codespell-ignore.*'
-# ignore-words-list = ''
+[tool.codespell]
+skip = '.git,package-lock.json,locale,AUTHORS,tox.ini'
+check-hidden = true
+ignore-regex = '.*pragma: codespell-ignore.*'
+ignore-words-list = 'assertIn'


### PR DESCRIPTION
pre-commit is raising code spell errors 
- ignore AUTHORS- we don't need to spell check names Savin was raising an error
- fix misspelling of compatibility in CHANGELOG.md
- ignore assertIn from the python unittest library.
