### PR TITLE
Correct rst syntax in installation section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Install with pip::
 
     pip install django-oauth-toolkit
 
-Add `oauth2_provider` to your `INSTALLED_APPS`
+Add ``oauth2_provider`` to your ``INSTALLED_APPS``
 
 .. code-block:: python
 
@@ -64,8 +64,8 @@ Add `oauth2_provider` to your `INSTALLED_APPS`
     )
 
 
-If you need an OAuth2 provider you'll want to add the following to your urls.py.
-Notice that `oauth2_provider` namespace is mandatory.
+If you need an OAuth2 provider you'll want to add the following to your ``urls.py``.
+Notice that ``oauth2_provider`` namespace is mandatory.
 
 .. code-block:: python
 


### PR DESCRIPTION
## Description of the Change

I noticed that the installation section in the README was using single backticks (\`) instead of double backticks (\`\`) to mark up some code. This works in Markdown, but doesn't really work in reStructuredText. While I was there I also tagged `urls.py`.

## Checklist

- [ ] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
