### PR TITLE
Drop re_path from installation guide

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -26,17 +26,6 @@ If you need an OAuth2 provider you'll want to add the following to your :file:`u
         path('o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     ]
 
-Or using ``re_path()``
-
-.. code-block:: python
-
-    from django.urls import include, re_path
-
-    urlpatterns = [
-        ...
-        re_path(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
-    ]
-
 Sync your database
 ------------------
 
@@ -45,4 +34,3 @@ Sync your database
     python manage.py migrate oauth2_provider
 
 Next step is :doc:`getting started <getting_started>` or :doc:`first tutorial <tutorial/tutorial_01>`.
-


### PR DESCRIPTION
## Description of the Change

Removed the bit about using `re_path` to add urls. It's just confusing, as a user I don't know why I should pick this option over the first one.

## Checklist

- [ ] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
