### PR TITLE
Handle invalid hex values in query strings in DRF extension

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -83,6 +83,7 @@ Kristian Rune Larsen
 Lazaros Toumanidis
 Ludwig Hähne
 Łukasz Skarżyński
+Madison Swain-Bowden
 Marcus Sonestedt
 Matias Seniquiel
 Michael Howitz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1425 Remove deprecated `RedirectURIValidator`, `WildcardSet` per #1345; `validate_logout_request` per #1274
 
 ### Fixed
+* #1443 Query strings with invalid hex values now raise a SuspiciousOperation exception (in DRF extension)
 ### Security
 
 ## [2.4.0] - 2024-05-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1425 Remove deprecated `RedirectURIValidator`, `WildcardSet` per #1345; `validate_logout_request` per #1274
 
 ### Fixed
-* #1443 Query strings with invalid hex values now raise a SuspiciousOperation exception (in DRF extension)
+* #1443 Query strings with invalid hex values now raise a SuspiciousOperation exception (in DRF extension) instead of raising a 500 ValueError: Invalid hex encoding in query string.
 ### Security
 
 ## [2.4.0] - 2024-05-13

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -415,3 +415,9 @@ class TestOAuth2Authentication(TestCase):
         auth = self._create_authorization_header(self.access_token.token)
         response = self.client.get("/oauth2-authentication-none/", HTTP_AUTHORIZATION=auth)
         self.assertEqual(response.status_code, 401)
+
+    def test_invalid_hex_string_in_query(self):
+        auth = self._create_authorization_header(self.access_token.token)
+        response = self.client.get("/oauth2-test/?q=73%%20of%20Arkansans", HTTP_AUTHORIZATION=auth)
+        # Should respond with a 400 rather than raise a ValueError
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1443

## Description of the Change

This PR applies a similar set of changes as #963 except for the Django Rest Framework contrib extension. I've tried my best to add tests for this case as well, but if there's anything else I'm missing please let me know!

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
