### PR TITLE
use user.pk instead of user.id

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -102,6 +102,7 @@ Rustem Saiargaliev
 Sandro Rodrigues
 Shaheed Haque
 Shaun Stanworth
+Sayyid Hamid Mahdavi
 Silvano Cerza
 Sora Yanai
 Spencer Carroll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1425 Remove deprecated `RedirectURIValidator`, `WildcardSet` per #1345; `validate_logout_request` per #1274
 
 ### Fixed
+* fix user pk in creating OIDC JWT token
 ### Security
 
 ## [2.4.0] - 2024-05-13

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -792,9 +792,9 @@ class OAuth2Validator(RequestValidator):
 
     def get_claim_dict(self, request):
         if self._get_additional_claims_is_request_agnostic():
-            claims = {"sub": lambda r: str(r.user.id)}
+            claims = {"sub": lambda r: str(r.user.pk)}
         else:
-            claims = {"sub": str(request.user.id)}
+            claims = {"sub": str(request.user.pk)}
 
         # https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
         if self._get_additional_claims_is_request_agnostic():


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes :
 * use user.pk instead of user.id

## Description of the Change

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [X] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [X] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
