### PR TITLE
drop support for Django versions below 4.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - '3.8'
-        - '3.9'
         - '3.10'
         - '3.11'
         - '3.12'
@@ -20,22 +18,12 @@ jobs:
         - '5.0'
         - '5.1'
         - 'main'
-        exclude:
+        include:
           # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
-
-          # < Python 3.10 is not supported by Django 5.0+
           - python-version: '3.8'
-            django-version: '5.0'
+            django-version: '4.2'
           - python-version: '3.9'
-            django-version: '5.0'
-          - python-version: '3.8'
-            django-version: '5.1'
-          - python-version: '3.9'
-            django-version: '5.1'
-          - python-version: '3.8'
-            django-version: 'main'
-          - python-version: '3.9'
-            django-version: 'main'
+            django-version: '4.2'
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,9 @@ jobs:
         - '3.11'
         - '3.12'
         django-version:
-        - '3.2'
-        - '4.0'
-        - '4.1'
         - '4.2'
         - '5.0'
+        - '5.1'
         - 'main'
         exclude:
           # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
@@ -31,19 +29,13 @@ jobs:
           - python-version: '3.9'
             django-version: '5.0'
           - python-version: '3.8'
+            django-version: '5.1'
+          - python-version: '3.9'
+            django-version: '5.1'
+          - python-version: '3.8'
             django-version: 'main'
           - python-version: '3.9'
             django-version: 'main'
-
-          # Python 3.12 is not supported by Django < 5.0
-          - python-version: '3.12'
-            django-version: '3.2'
-          - python-version: '3.12'
-            django-version: '4.0'
-          - python-version: '3.12'
-            django-version: '4.1'
-          - python-version: '3.12'
-            django-version: '4.2'
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 * #1425 Remove deprecated `RedirectURIValidator`, `WildcardSet` per #1345; `validate_logout_request` per #1274
-* Remove support for Django below 4.2
+* Remove support for Django versions below 4.2
 
 ### Fixed
 * #1443 Query strings with invalid hex values now raise a SuspiciousOperation exception (in DRF extension) instead of raising a 500 ValueError: Invalid hex encoding in query string.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 * #1425 Remove deprecated `RedirectURIValidator`, `WildcardSet` per #1345; `validate_logout_request` per #1274
+* Remove support for Django below 4.2
 
 ### Fixed
 * #1443 Query strings with invalid hex values now raise a SuspiciousOperation exception (in DRF extension) instead of raising a 500 ValueError: Invalid hex encoding in query string.

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Requirements
 ------------
 
 * Python 3.8+
-* Django 3.2, 4.0 (4.0.1+ due to a regression), 4.1, 4.2, or 5.0
+* Django 4.2, 5.0 and 5.1
 * oauthlib 3.1+
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Requirements
 ------------
 
 * Python 3.8+
-* Django 4.2, 5.0 and 5.1
+* Django 4.2, 5.0 or 5.1
 * oauthlib 3.1+
 
 Installation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 * Python 3.8+
-* Django 4.2, 5.0 and 5.1
+* Django 4.2, 5.0 or 5.1
 * oauthlib 3.1+
 
 Index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 * Python 3.8+
-* Django 3.2, 4.0 (4.0.1+ due to a regression), 4.1, 4.2, or 5.0
+* Django 4.2, 5.0 and 5.1
 * oauthlib 3.1+
 
 Index

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,11 +12,9 @@ classifiers =
 	Development Status :: 5 - Production/Stable
 	Environment :: Web Environment
 	Framework :: Django
-	Framework :: Django :: 3.2
-	Framework :: Django :: 4.0
-	Framework :: Django :: 4.1
 	Framework :: Django :: 4.2
 	Framework :: Django :: 5.0
+	Framework :: Django :: 5.1
 	Intended Audience :: Developers
 	License :: OSI Approved :: BSD License
 	Operating System :: OS Independent
@@ -36,7 +34,7 @@ python_requires = >=3.8
 # jwcrypto has a direct dependency on six, but does not list it yet in a release
 # Previously, cryptography also depended on six, so this was unnoticed
 install_requires =
-	django >= 3.2, != 4.0.0
+	django >= 4.2
 	requests >= 2.13.0
 	oauthlib >= 3.1.0
 	jwcrypto >= 0.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,9 @@ envlist =
     migrate_swapped,
     docs,
     sphinxlint,
-    py{38,39,310}-dj32,
-    py{38,39,310}-dj40,
-    py{38,39,310,311}-dj41,
     py{38,39,310,311,312}-dj42,
     py{310,311,312}-dj50,
+    py{310,311,312}-dj51,
     py{310,311,312}-djmain,
 
 [gh-actions]
@@ -22,12 +20,9 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    2.2: dj22
-    3.2: dj32
-    4.0: dj40
-    4.1: dj41
     4.2: dj42
     5.0: dj50
+    5.1: dj51
     main: djmain
 
 [pytest]
@@ -50,12 +45,9 @@ setenv =
     PYTHONPATH = {toxinidir}
     PYTHONWARNINGS = all
 deps =
-    dj22: Django>=2.2,<3
-    dj32: Django>=3.2,<3.3
-    dj40: Django>=4.0.0,<4.1
-    dj41: Django>=4.1,<4.2
     dj42: Django>=4.2,<4.3
-    dj50: Django>=5.0b1,<5.1
+    dj50: Django>=5.0,<5.1
+    dj51: Django>=5.1,<5.2
     djmain: https://github.com/django/django/archive/main.tar.gz
     djangorestframework
     oauthlib>=3.1.0


### PR DESCRIPTION
## Description of the Change

Django versions below 4.2 are no longer supported, so this PR removes mentions and CI for these versions.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
