### PR TITLE
check format using ruff

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   ruff:
+    name: Ruff
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -14,6 +15,6 @@ jobs:
     - name: Install Ruff
       run: |
         python -m pip install ruff>=0.5
-    - name: Ruff
+    - name: Format check (Ruff)
       run: |
         ruff format --check

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,20 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test-package:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install Ruff
+      run: |
+        python -m pip install ruff>=0.5
+    - name: Ruff
+      run: |
+        ruff format --check

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,10 +1,9 @@
-name: Test
+name: Lint
 
 on: [push, pull_request]
 
 jobs:
-  test-package:
-    name: Lint
+  ruff:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ pip-log.txt
 .coverage
 .tox
 .pytest_cache/
+.ruff_cache/
 nosetests.xml
 
 # Translations

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,8 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.8.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.7
     hooks:
-      - id: black
-        exclude: ^(oauth2_provider/migrations/|tests/migrations/)
+      - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,10 @@
-[tool.black]
-line-length = 110
-target-version = ['py38']
-exclude = '''
-^/(
-        oauth2_provider/migrations/
-    |   tests/migrations/
-    |   .tox
-)
-'''
-
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 [tool.codespell]
 skip = '.git,package-lock.json,locale,AUTHORS,tox.ini'
 check-hidden = true
 ignore-regex = '.*pragma: codespell-ignore.*'
 ignore-words-list = 'assertIn'
+
+[tool.ruff]
+line-length = 110
+exclude = [".tox", "oauth2_provider/migrations/", "tests/migrations/", "manage.py"]

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ markers =
 
 [testenv]
 commands =
+    ruff format
     pytest {posargs}
     coverage report
     coverage xml
@@ -67,6 +68,7 @@ deps =
     pytest-xdist
     pytest-mock
     requests
+    ruff>=0.5
 passenv =
     PYTEST_ADDOPTS
 
@@ -106,7 +108,6 @@ deps =
     flake8
     flake8-isort
     flake8-quotes
-    flake8-black
 
 [testenv:migrations]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,6 @@ markers =
 
 [testenv]
 commands =
-    ruff format --check
     pytest {posargs}
     coverage report
     coverage xml
@@ -68,7 +67,6 @@ deps =
     pytest-xdist
     pytest-mock
     requests
-    ruff>=0.5
 passenv =
     PYTEST_ADDOPTS
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ markers =
 
 [testenv]
 commands =
-    ruff format
+    ruff format --check
     pytest {posargs}
     coverage report
     coverage xml


### PR DESCRIPTION
## Description of the Change

Format check using Ruff in separate job, because it doesn't depend on neither  Python nor Django versions. I'm planning to replace isort and flake8 with Ruff in coming days.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
