### PR TITLE
replace isort with ruff

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,8 @@ jobs:
         python-version: "3.10"
     - name: Install Ruff
       run: |
-        python -m pip install ruff>=0.5
-    - name: Format check (Ruff)
+        python -m pip install ruff>=0.6
+    - name: Lint using Ruff
       run: |
         ruff format --check
+        ruff check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,9 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.7
+    rev: v0.6.0
     hooks:
+      - id: ruff
+        args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
@@ -14,11 +16,6 @@ repos:
       - id: check-yaml
       - id: mixed-line-ending
         args: ['--fix=lf']
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        exclude: ^(oauth2_provider/migrations/|tests/migrations/)
   - repo: https://github.com/PyCQA/flake8
     rev: 7.1.1
     hooks:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -28,13 +28,12 @@ Code Style
 ==========
 
 The project uses `flake8 <https://flake8.pycqa.org/en/latest/>`_ for linting,
-`black <https://black.readthedocs.io/en/stable/>`_ for formatting the code,
-`isort <https://pycqa.github.io/isort/>`_ for formatting and sorting imports,
+`ruff <https://docs.astral.sh/ruff/>`_ for formatting the code and sorting imports,
 and `pre-commit <https://pre-commit.com/>`_ for checking/fixing commits for
 correctness before they are made.
 
 You will need to install ``pre-commit`` yourself, and then ``pre-commit`` will
-take care of installing ``flake8``, ``black`` and ``isort``.
+take care of installing ``flake8`` and ``ruff``.
 
 After cloning your repository, go into it and run::
 
@@ -42,14 +41,14 @@ After cloning your repository, go into it and run::
 
 to install the hooks. On the next commit that you make, ``pre-commit`` will
 download and install the necessary hooks (a one off task). If anything in the
-commit would fail the hooks, the commit will be abandoned. For ``black`` and
-``isort``, any necessary changes will be made automatically, but not staged.
+commit would fail the hooks, the commit will be abandoned. For ``ruff``, any
+necessary changes will be made automatically, but not staged.
 Review the changes, and then re-stage and commit again.
 
 Using ``pre-commit`` ensures that code that would fail in QA does not make it
 into a commit in the first place, and will save you time in the long run. You
 can also (largely) stop worrying about code style, although you should always
-check how the code looks after ``black`` has formatted it, and think if there
+check how the code looks after ``ruff`` has formatted it, and think if there
 is a better way to structure the code so that it is more readable.
 
 Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,10 @@ ignore-words-list = 'assertIn'
 [tool.ruff]
 line-length = 110
 exclude = [".tox", "oauth2_provider/migrations/", "tests/migrations/", "manage.py"]
+
+[tool.ruff.lint]
+select = ["I", "Q"]
+
+[tool.ruff.lint.isort]
+lines-after-imports = 2
+known-first-party = ["oauth2_provider"]

--- a/tox.ini
+++ b/tox.ini
@@ -97,8 +97,6 @@ skip_install = True
 commands = flake8 {toxinidir}
 deps =
     flake8
-    flake8-isort
-    flake8-quotes
 
 [testenv:migrations]
 setenv =
@@ -137,15 +135,3 @@ exclude = docs/, oauth2_provider/migrations/, tests/migrations/, .tox/, build/, 
 application-import-names = oauth2_provider
 inline-quotes = double
 extend-ignore = E203, W503
-
-[isort]
-default_section = THIRDPARTY
-known_first_party = oauth2_provider
-line_length = 110
-lines_after_imports = 2
-multi_line_output = 3
-include_trailing_comma = True
-force_grid_wrap = 0
-use_parentheses = True
-ensure_newline_before_comments = True
-skip = oauth2_provider/migrations/, .tox/, tests/migrations/


### PR DESCRIPTION
## Description of the Change

This PR replaces isort with ruff, already introduced in https://github.com/jazzband/django-oauth-toolkit/pull/1457 for format checking.

`I` enables isort and `Q` enables flake8-quotes rules.

```toml
[tool.ruff.lint]
select = ["I", "Q"]
```
## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
