### PR TITLE
replace flake8 with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,11 +16,6 @@ repos:
       - id: check-yaml
       - id: mixed-line-ending
         args: ['--fix=lf']
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
-    hooks:
-      - id: flake8
-        exclude: ^(oauth2_provider/migrations/|tests/migrations/)
   - repo: https://github.com/sphinx-contrib/sphinx-lint
     rev: v0.9.1
     hooks:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -27,13 +27,11 @@ add a comment stating you're working on it.
 Code Style
 ==========
 
-The project uses `flake8 <https://flake8.pycqa.org/en/latest/>`_ for linting,
-`ruff <https://docs.astral.sh/ruff/>`_ for formatting the code and sorting imports,
-and `pre-commit <https://pre-commit.com/>`_ for checking/fixing commits for
-correctness before they are made.
+The project uses `ruff <https://docs.astral.sh/ruff/>`_ for linting, formatting the code and sorting imports,
+and `pre-commit <https://pre-commit.com/>`_ for checking/fixing commits for correctness before they are made.
 
 You will need to install ``pre-commit`` yourself, and then ``pre-commit`` will
-take care of installing ``flake8`` and ``ruff``.
+take care of installing ``ruff``.
 
 After cloning your repository, go into it and run::
 
@@ -264,7 +262,7 @@ add a comment. If you think a function is not trivial, add a docstrings.
 
 To see if your code formatting will pass muster use::
 
-  tox -e flake8
+  tox -e lint
 
 The contents of this page are heavily based on the docs from `django-admin2 <https://github.com/twoscoops/django-admin2>`_
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,10 @@ ignore-words-list = 'assertIn'
 
 [tool.ruff]
 line-length = 110
-exclude = [".tox", "oauth2_provider/migrations/", "tests/migrations/", "manage.py"]
+exclude = [".tox", "build/", "dist/", "docs/", "oauth2_provider/migrations/", "tests/migrations/", "manage.py"]
 
 [tool.ruff.lint]
-select = ["I", "Q"]
+select = ["E", "F", "I", "Q", "W"]
 
 [tool.ruff.lint.isort]
 lines-after-imports = 2

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    flake8,
     migrations,
     migrate_swapped,
     docs,
+    lint,
     sphinxlint,
     py{38,39,310,311,312}-dj42,
     py{310,311,312}-dj50,
@@ -12,7 +12,7 @@ envlist =
 
 [gh-actions]
 python =
-    3.8: py38, docs, flake8, migrations, migrate_swapped, sphinxlint
+    3.8: py38, docs, lint, migrations, migrate_swapped, sphinxlint
     3.9: py39
     3.10: py310
     3.11: py311
@@ -92,12 +92,13 @@ deps =
     jwcrypto
     django
 
-[testenv:flake8]
+[testenv:lint]
 basepython = python3.8
+deps = ruff>=0.6
 skip_install = True
-commands = flake8 {toxinidir}
-deps =
-    flake8
+commands =
+    ruff format --check
+    ruff check
 
 [testenv:migrations]
 setenv =
@@ -129,10 +130,3 @@ omit = */migrations/*
 
 [coverage:report]
 show_missing = True
-
-[flake8]
-max-line-length = 110
-exclude = docs/, oauth2_provider/migrations/, tests/migrations/, .tox/, build/, dist/
-application-import-names = oauth2_provider
-inline-quotes = double
-extend-ignore = E203, W503


### PR DESCRIPTION
## Description of the Change

This PR replaces flake8 with ruff, and enables following rules.
- E, W - pycodestyle
- F - pyflakes

Run ```tox -e lint``` to test the changes.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
