### PR TITLE
centralize tools config in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,26 @@ check-hidden = true
 ignore-regex = '.*pragma: codespell-ignore.*'
 ignore-words-list = 'assertIn'
 
+[tool.coverage.run]
+source = ["oauth2_provider"]
+omit = ["*/migrations/*"]
+
+[tool.coverage.report]
+show_missing = true
+
+[tool.pytest.ini_options]
+django_find_project = false
+addopts = [
+    "--cov=oauth2_provider",
+    "--cov-report=",
+    "--cov-append",
+    "-s"
+]
+markers = [
+    "oauth2_settings: Custom OAuth2 settings to use - use with oauth2_settings fixture",
+    "nologinrequiredmiddleware",
+]
+
 [tool.ruff]
 line-length = 110
 exclude = [".tox", "build/", "dist/", "docs/", "oauth2_provider/migrations/", "tests/migrations/", "manage.py"]

--- a/tox.ini
+++ b/tox.ini
@@ -25,17 +25,6 @@ DJANGO =
     5.1: dj51
     main: djmain
 
-[pytest]
-django_find_project = false
-addopts =
-    --cov=oauth2_provider
-    --cov-report=
-    --cov-append
-    -s
-markers =
-    oauth2_settings: Custom OAuth2 settings to use - use with oauth2_settings fixture
-    nologinrequiredmiddleware
-
 [testenv]
 commands =
     pytest {posargs}
@@ -124,10 +113,3 @@ commands =
     rm -rf dist
     python -m build
     twine check dist/*
-
-[coverage:run]
-source = oauth2_provider
-omit = */migrations/*
-
-[coverage:report]
-show_missing = True


### PR DESCRIPTION
## Description of the Change

I found that configurations of tools split into pyproject.toml and tox.ini, thus confusing. This PR centralizes all tools configuration into pyproject.toml. 

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
