### PR TITLE
bump oauthlib to 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Update token to TextField from CharField with 255 character limit and SHA-256 checksum in AbstractAccessToken model. Removing the 255 character limit enables supporting JWT tokens with additional claims
 * Update middleware, validators, and views to use token checksums instead of token for token retrieval and validation.
 * #1446 use generic models pk instead of id.
+* Bump oauthlib version to 3.2.0 and above
 
 ### Deprecated
 ### Removed

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Requirements
 
 * Python 3.8+
 * Django 4.2, 5.0 or 5.1
-* oauthlib 3.1+
+* oauthlib 3.2+
 
 Installation
 ------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Requirements
 
 * Python 3.8+
 * Django 4.2, 5.0 or 5.1
-* oauthlib 3.1+
+* oauthlib 3.2+
 
 Index
 =====

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 Django
-oauthlib>=3.1.0
+oauthlib>=3.2.0
 m2r>=0.2.1
 mistune<2
 sphinx==7.2.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dependencies = [
 	"django >= 4.2",
 	"requests >= 2.13.0",
-	"oauthlib >= 3.1.0",
+	"oauthlib >= 3.2.0",
 	"jwcrypto >= 0.8.0",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps =
     dj51: Django>=5.1,<5.2
     djmain: https://github.com/django/django/archive/main.tar.gz
     djangorestframework
-    oauthlib>=3.1.0
+    oauthlib>=3.2.0
     jwcrypto
     coverage
     pytest
@@ -73,7 +73,7 @@ commands =
 deps =
     Jinja2<3.1
     sphinx<3
-    oauthlib>=3.1.0
+    oauthlib>=3.2.0
     m2r>=0.2.1
     mistune<2
     sphinx-rtd-theme


### PR DESCRIPTION
## Description of the Change

This PR bumps oauthlib version to 3.2, which was releases in 2022.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
