### PR TITLE
Work around double parsing of ui_locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * #1443 Query strings with invalid hex values now raise a SuspiciousOperation exception (in DRF extension) instead of raising a 500 ValueError: Invalid hex encoding in query string.
+* #1468 `ui_locales` request parameter triggers `AttributeError` under certain circumstances
 ### Security
 
 ## [2.4.0] - 2024-05-13

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -186,6 +186,10 @@ class AuthorizationView(BaseAuthorizationView, FormView):
         # a successful response depending on "approval_prompt" url parameter
         require_approval = request.GET.get("approval_prompt", oauth2_settings.REQUEST_APPROVAL_PROMPT)
 
+        if "ui_locales" in credentials and isinstance(credentials["ui_locales"], list):
+            # Make sure ui_locales a space separated string for oauthlib to handle it correctly.
+            credentials["ui_locales"] = " ".join(credentials["ui_locales"])
+
         try:
             # If skip_authorization field is True, skip the authorization screen even
             # if this is the first use of the application and there was no previous authorization.

--- a/tests/test_ui_locales.py
+++ b/tests/test_ui_locales.py
@@ -4,17 +4,20 @@ from django.urls import reverse
 
 from oauth2_provider.models import get_application_model
 
+
 UserModel = get_user_model()
 Application = get_application_model()
 
 
-@override_settings(OAUTH2_PROVIDER={
-    "OIDC_ENABLED": True,
-    "PKCE_REQUIRED": False,
-    "SCOPES": {
-        "openid": "OpenID connect",
-    },
-})
+@override_settings(
+    OAUTH2_PROVIDER={
+        "OIDC_ENABLED": True,
+        "PKCE_REQUIRED": False,
+        "SCOPES": {
+            "openid": "OpenID connect",
+        },
+    }
+)
 class TestUILocalesParam(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/tests/test_ui_locales.py
+++ b/tests/test_ui_locales.py
@@ -1,0 +1,54 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from oauth2_provider.models import get_application_model
+
+UserModel = get_user_model()
+Application = get_application_model()
+
+
+@override_settings(OAUTH2_PROVIDER={
+    "OIDC_ENABLED": True,
+    "PKCE_REQUIRED": False,
+    "SCOPES": {
+        "openid": "OpenID connect",
+    },
+})
+class TestUILocalesParam(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.application = Application.objects.create(
+            name="Test Application",
+            client_id="test",
+            redirect_uris="https://www.example.com/",
+            client_type=Application.CLIENT_PUBLIC,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        cls.trusted_application = Application.objects.create(
+            name="Trusted Application",
+            client_id="trusted",
+            redirect_uris="https://www.example.com/",
+            client_type=Application.CLIENT_PUBLIC,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            skip_authorization=True,
+        )
+        cls.user = UserModel.objects.create_user("test_user")
+        cls.url = reverse("oauth2_provider:authorize")
+
+    def setUp(self):
+        self.client.force_login(self.user)
+
+    def test_application_ui_locales_param(self):
+        response = self.client.get(
+            f"{self.url}?response_type=code&client_id=test&scope=openid&ui_locales=de",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "oauth2_provider/authorize.html")
+
+    def test_trusted_application_ui_locales_param(self):
+        response = self.client.get(
+            f"{self.url}?response_type=code&client_id=trusted&scope=openid&ui_locales=de",
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertRegex(response.url, r"https://www\.example\.com/\?code=[a-zA-Z0-9]+")


### PR DESCRIPTION
Fixes #1468

## Description of the Change

Makes sure `credential["ui_locales"] is a string before passing it to `oauthlib`.

`oauthlib` always calls `split` on the values of `ui_locales`:

https://github.com/oauthlib/oauthlib/blob/d319c54ae0342d9a2596ef7afa1e17984c303550/oauthlib/openid/connect/core/grant_types/base.py#L317

The way django-oauth-toolkit is structured the `credentials` dictionary contains the value of `ui_locales` as processed by `oauthlib`, which makes it a list. It is then passed back into `oauthlib` which tries to parse it again, resulting in an `AttributeError`.

`oauthlib` is a bit more careful with the way it handles the `prompt` parameter:

https://github.com/oauthlib/oauthlib/blob/d319c54ae0342d9a2596ef7afa1e17984c303550/oauthlib/openid/connect/core/grant_types/base.py#L289-L292

So this might be a bug in the way `oauthlib` handles the incoming `ui_locales` parameter.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
