### PR TITLE
Raise InvalidGrantError if no associated grant exists when invalidating an authorization code

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -119,3 +119,4 @@ pySilver
 Wouter Klein Heerenbrink
 Yaroslav Halchenko
 Yuri Savin
+Miriam Forner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Update middleware, validators, and views to use token checksums instead of token for token retrieval and validation.
 * #1446 use generic models pk instead of id.
 * Bump oauthlib version to 3.2.0 and above
+* Update the OAuth2Validator's invalidate_authorization_code method to return an InvalidGrantError if the associated grant does not exist.
 
 ### Deprecated
 ### Removed

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -9,9 +9,15 @@ from django.test import TestCase, TransactionTestCase
 from django.utils import timezone
 from jwcrypto import jwt
 from oauthlib.common import Request
+from oauthlib.oauth2.rfc6749 import errors as rfc6749_errors
 
 from oauth2_provider.exceptions import FatalClientError
-from oauth2_provider.models import get_access_token_model, get_application_model, get_refresh_token_model
+from oauth2_provider.models import (
+    get_access_token_model,
+    get_application_model,
+    get_grant_model,
+    get_refresh_token_model,
+)
 from oauth2_provider.oauth2_backends import get_oauthlib_core
 from oauth2_provider.oauth2_validators import OAuth2Validator
 
@@ -28,6 +34,7 @@ except ImportError:
 UserModel = get_user_model()
 Application = get_application_model()
 AccessToken = get_access_token_model()
+Grant = get_grant_model()
 RefreshToken = get_refresh_token_model()
 
 CLEARTEXT_SECRET = "1234567890abcdefghijklmnopqrstuvwxyz"
@@ -578,3 +585,14 @@ def test_validate_id_token_bad_token_no_aud(oauth2_settings, mocker, oidc_key):
     validator = OAuth2Validator()
     status = validator.validate_id_token(token.serialize(), ["openid"], mocker.sentinel.request)
     assert status is False
+
+
+@pytest.mark.django_db
+def test_invalidate_authorization_token_returns_invalid_grant_error_when_grant_does_not_exist():
+    client_id = "123"
+    code = "12345"
+    request = Request("/")
+    assert Grant.objects.all().count() == 0
+    with pytest.raises(rfc6749_errors.InvalidGrantError):
+        validator = OAuth2Validator()
+        validator.invalidate_authorization_code(client_id=client_id, code=code, request=request)


### PR DESCRIPTION
## Description of the Change
This change raises an `InvalidGrantError` from the `OAuth2Validator.invalidate_authorization_code` method if the Grant object intended to be deleted does not exist.

Currently, when invalidating an authorization code after it has been used, if for whatever reason the associated grant object no longer exists, an uncaught `Grant.DoesNotExist` exception is raised. This leads to 500 responses being returned to clients. This could, for example, be caused by concurrent requests being made using the same authorization code.

The change in this PR handles this scenario gracefully by catching `Grant.DoesNotExist` and raising an `InvalidGrantError` which will return a 400 'invalid_grant' response to the client.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated (No existing documentation for this validator class)
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
