### PR TITLE
Fix test for changed error message from newer Django (djmain)

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -145,6 +145,5 @@ class CreateApplicationTest(TestCase):
         self.assertIn("783", output_str)
         # newer Django (>5.1) changes the error message from "does not exist" to "is not a valid choice"
         self.assertTrue(
-            any(substring in output_str for substring in ["does not exist", "is not a valid choice"]),
-            f"Output did not contain 'does not exist' or 'is not a valid choice'. Actual output: {output_str}",
+            any(substring in output_str for substring in ["does not exist", "is not a valid choice"])
         )

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -140,6 +140,11 @@ class CreateApplicationTest(TestCase):
             stdout=output,
         )
 
-        self.assertIn("user", output.getvalue())
-        self.assertIn("783", output.getvalue())
-        self.assertIn("does not exist", output.getvalue())
+        output_str = output.getvalue()
+        self.assertIn("user", output_str)
+        self.assertIn("783", output_str)
+        # newer Django (>5.1) changes the error message from "does not exist" to "is not a valid choice"
+        self.assertTrue(
+            any(substring in output_str for substring in ["does not exist", "is not a valid choice"]),
+            f"Output did not contain 'does not exist' or 'is not a valid choice'. Actual output: {output_str}",
+        )

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -130,6 +130,8 @@ class CreateApplicationTest(TestCase):
         self.assertEqual(app.algorithm, "RS256")
 
     def test_validation_failed_message(self):
+        import django
+
         output = StringIO()
         call_command(
             "createapplication",
@@ -143,7 +145,7 @@ class CreateApplicationTest(TestCase):
         output_str = output.getvalue()
         self.assertIn("user", output_str)
         self.assertIn("783", output_str)
-        # newer Django (>5.1) changes the error message from "does not exist" to "is not a valid choice"
-        self.assertTrue(
-            any(substring in output_str for substring in ["does not exist", "is not a valid choice"])
-        )
+        if django.VERSION < (5, 2):
+            self.assertIn("does not exist", output_str)
+        else:
+            self.assertIn("is not a valid choice", output_str)


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1482

## Description of the Change
Older Django has one error message that the failure test was looking for. Newer Django (main branch) has a different error message, so check for both.
 
## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
