### PR TITLE
Support for specifying client secret hasher

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -86,6 +86,7 @@ Ludwig Hähne
 Łukasz Skarżyński
 Madison Swain-Bowden
 Marcus Sonestedt
+Matej Spiller Muys
 Matias Seniquiel
 Michael Howitz
 Owen Gong

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!--
 ## [unreleased]
 ### Added
+* Support for specifying client secret hasher via CLIENT_SECRET_HASHER setting.
 ### Changed
 ### Deprecated
 ### Removed

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -104,6 +104,10 @@ CLIENT_SECRET_GENERATOR_LENGTH
 The length of the generated secrets, in characters. If this value is too low,
 secrets may become subject to bruteforce guessing.
 
+CLIENT_SECRET_HASHER
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The hasher for storing generated secrets. By default library will use the first hasher in PASSWORD_HASHERS.
+
 EXTRA_SERVER_KWARGS
 ~~~~~~~~~~~~~~~~~~~
 A dictionary to be passed to oauthlib's Server class. Three options

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -40,7 +40,7 @@ class ClientSecretField(models.CharField):
             logger.debug(f"{model_instance}: {self.attname} is already hashed with {hasher}.")
         except ValueError:
             logger.debug(f"{model_instance}: {self.attname} is not hashed; hashing it now.")
-            hashed_secret = make_password(secret)
+            hashed_secret = make_password(secret, hasher=oauth2_settings.CLIENT_SECRET_HASHER)
             setattr(model_instance, self.attname, hashed_secret)
             return hashed_secret
         return super().pre_save(model_instance, add)

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -37,6 +37,7 @@ DEFAULTS = {
     "CLIENT_ID_GENERATOR_CLASS": "oauth2_provider.generators.ClientIdGenerator",
     "CLIENT_SECRET_GENERATOR_CLASS": "oauth2_provider.generators.ClientSecretGenerator",
     "CLIENT_SECRET_GENERATOR_LENGTH": 128,
+    "CLIENT_SECRET_HASHER": "default",
     "ACCESS_TOKEN_GENERATOR": None,
     "REFRESH_TOKEN_GENERATOR": None,
     "EXTRA_SERVER_KWARGS": {},

--- a/tests/custom_hasher.py
+++ b/tests/custom_hasher.py
@@ -1,0 +1,10 @@
+from django.contrib.auth.hashers import PBKDF2PasswordHasher
+
+
+class MyPBKDF2PasswordHasher(PBKDF2PasswordHasher):
+    """
+    A subclass of PBKDF2PasswordHasher that uses less iterations.
+    """
+
+    algorithm = "fast_pbkdf2"
+    iterations = 10000

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -89,6 +89,8 @@ INSTALLED_APPS = (
     "tests",
 )
 
+PASSWORD_HASHERS = django.conf.settings.PASSWORD_HASHERS + ["tests.custom_hasher.MyPBKDF2PasswordHasher"]
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -72,6 +72,22 @@ class TestModels(BaseTestModels):
         self.assertNotEqual(app.client_secret, CLEARTEXT_SECRET)
         self.assertTrue(check_password(CLEARTEXT_SECRET, app.client_secret))
 
+    @override_settings(OAUTH2_PROVIDER={"CLIENT_SECRET_HASHER": "fast_pbkdf2"})
+    def test_hashed_from_settings(self):
+        app = Application.objects.create(
+            name="test_app",
+            redirect_uris="http://localhost http://example.com http://example.org",
+            user=self.user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            client_secret=CLEARTEXT_SECRET,
+            hash_client_secret=True,
+        )
+
+        self.assertNotEqual(app.client_secret, CLEARTEXT_SECRET)
+        self.assertIn("fast_pbkdf2", app.client_secret)
+        self.assertTrue(check_password(CLEARTEXT_SECRET, app.client_secret))
+
     def test_unhashed_secret(self):
         app = Application.objects.create(
             name="test_app",


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
With every Django version PBKDF2 password hasher gets iterations increased and the next one will be set to 1 mio.
This poses a problem in our case because it affects the performance of /token endpoint. We whitelist to the IPs from which endpoint is accessible so we want to use weaker algorithm. For normal UI login we still want to retain default one.

## Description of the Change
Added a setting for specifying client server hasher using CLIENT_SECRET_HASHER.


## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [X] PR only contains one change (considered splitting up PR)
- [X] unit-test added
- [X] documentation updated
- [X] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
