### PR TITLE
Add client_secret to sensitive_post_parameters

### DIFF
--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -292,7 +292,7 @@ class TokenView(OAuthLibMixin, View):
     * Client credentials
     """
 
-    @method_decorator(sensitive_post_parameters("password"))
+    @method_decorator(sensitive_post_parameters("password", "client_secret"))
     def post(self, request, *args, **kwargs):
         url, headers, body, status = self.create_token_response(request)
         if status == 200:


### PR DESCRIPTION
The client_secret is posted to the token endpoint when using the client_credentials grant.

(sorry just a basic drive-by PR because I noticed this while debugging something else)