### PR TITLE
fix: OP prompts for logout when no OP session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 ### Added
-* Support for Wildcard Origin and Redirect URIs, https://github.com/jazzband/django-oauth-toolkit/issues/1506
+* #1506 Support for Wildcard Origin and Redirect URIs
 <!--
 ### Changed
 ### Deprecated
 ### Removed
+-->
 ### Fixed
+* #1517 OP prompts for logout when no OP session
+* #1512 client_secret not marked sensitive
+<!--
 ### Security
 -->
 


### PR DESCRIPTION
The OAuth provider is prompting users who no longer have an user session with the OAuth Provider to logout of the OP. This happens in scenarios given the user has logged out of the OP directly or via another client. In cases where the user does not have a session on the OP we should not prompt them to log out of the OP as there is no session, but we should still clear out their tokens to terminate the session for the Application.

I also renamed a test that used expired_session in the name to without_op_session. I believe that was their original intent, @tonial can you confirm? 

## Checklist

- [X] PR only contains one change (considered splitting up PR)
- [X] unit-test added
- [X] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
