### PR TITLE
Use iterator in access token migration

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -122,3 +122,4 @@ Wouter Klein Heerenbrink
 Yaroslav Halchenko
 Yuri Savin
 Miriam Forner
+Alex Kerkum

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * #1517 OP prompts for logout when no OP session
 * #1512 client_secret not marked sensitive
+* #1521 Fix 0012 migration loading access token table into memory
 <!--
 ### Security
 -->

--- a/oauth2_provider/migrations/0012_add_token_checksum.py
+++ b/oauth2_provider/migrations/0012_add_token_checksum.py
@@ -9,7 +9,7 @@ def forwards_func(apps, schema_editor):
     Forward migration touches every "old" accesstoken.token which will cause the checksum to be computed.
     """
     AccessToken = apps.get_model(oauth2_settings.ACCESS_TOKEN_MODEL)
-    accesstokens = AccessToken._default_manager.all()
+    accesstokens = AccessToken._default_manager.iterator()
     for accesstoken in accesstokens:
         accesstoken.save(update_fields=['token_checksum'])
 


### PR DESCRIPTION
Fixes #1521

## Description of the Change

This PR uses `.iterator()` instead of `.all()` in the `0012_add_token_checksum` migration to prevent reading the whole table into memory.

I'm not sure if it makes sense to unittest this.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
