### PR TITLE
Fix range of allowed django versions

### DIFF
--- a/tests/app/idp/requirements.txt
+++ b/tests/app/idp/requirements.txt
@@ -1,4 +1,4 @@
-Django>=3.2,<4.2
+Django>=3.2,<=4.2
 django-cors-headers==3.14.0
 django-environ==0.11.2
 

--- a/tests/app/idp/requirements.txt
+++ b/tests/app/idp/requirements.txt
@@ -1,4 +1,4 @@
-Django>=3.2,<=4.2
+Django>=4.2,<=5.1
 django-cors-headers==3.14.0
 django-environ==0.11.2
 


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #

## Description of the Change
Running `docker-compose build` fails at the moment due to a package resolution conflict. Allowing to use Django 4.2 solves the issue.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`


