### PR TITLE
Easier docker setup for development environment

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-# required for vscode testing activity to discover tests
-DJANGO_SETTINGS_MODULE=tests.settings

--- a/.env.sample.docker
+++ b/.env.sample.docker
@@ -1,0 +1,1 @@
+DEBUG=0  #  Change to any non-zero number to enable debug mode

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ db.sqlite3
 venv/
 
 /tests/app/idp/static
+
+# files with environment variables
+.env

--- a/AUTHORS
+++ b/AUTHORS
@@ -99,6 +99,7 @@ Peter Karman
 Peter McDonald
 Petr Dlouhý
 pySilver
+Raphael Lullis
 Rodney Richardson
 Rustem Saiargaliev
 Rustem Saiargaliev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 ### Added
 * #1506 Support for Wildcard Origin and Redirect URIs
+
+### Changed
+* #1548 Docker and docker-compose to run test applications
+
 <!--
 ### Changed
 ### Deprecated

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,34 +4,6 @@
 # tests/app/idp. This way we build images with the source
 # code from the repos for validation before publishing packages.
 
-FROM python:3.11.6-slim as builder
-
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
-
-ENV DEBUG=False
-ENV ALLOWED_HOSTS="*"
-ENV TEMPLATES_DIRS="/data/templates"
-ENV STATIC_ROOT="/data/static"
-ENV DATABASE_URL="sqlite:////data/db.sqlite3"
-
-RUN apt-get update
-# Build Deps
-RUN apt-get install -y --no-install-recommends gcc libc-dev python3-dev git openssh-client libpq-dev file libev-dev
-# bundle code in a virtual env to make copying to the final image without all the upstream stuff easier.
-RUN python -m venv /opt/venv
-ENV PATH="/opt/venv/bin:$PATH"
-# need to update pip and setuptools for pep517 support required by gevent.
-RUN pip install --upgrade pip
-RUN pip install --upgrade setuptools
-COPY . /code
-WORKDIR /code/tests/app/idp
-RUN pip install -r requirements.txt
-RUN pip install gunicorn
-RUN python manage.py collectstatic --noinput
-
-
-
 FROM python:3.11.6-slim
 
 # allow embed sha1 at build time as release.
@@ -41,27 +13,29 @@ LABEL org.opencontainers.image.authors="https://jazzband.co/projects/django-oaut
 LABEL org.opencontainers.image.source="https://github.com/jazzband/django-oauth-toolkit"
 LABEL org.opencontainers.image.revision=${GIT_SHA1}
 
+RUN pip install --upgrade pip setuptools uv
 
 ENV SENTRY_RELEASE=${GIT_SHA1}
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+ENV UV_CACHE_DIR /var/cache/uv
+ENV UV_PROJECT_ENVIRONMENT /opt/dot/venv
 
-# disable debug mode, but allow all hosts by default when running in docker
-ENV DEBUG=False
-ENV ALLOWED_HOSTS="*"
-ENV TEMPLATES_DIRS="/data/templates"
-ENV STATIC_ROOT="/data/static"
-ENV DATABASE_URL="sqlite:////data/db.sqlite3"
+RUN apt-get update
+# Build Deps
+RUN apt-get install -y --no-install-recommends libc-dev python3-dev file libev-dev
+# bundle code in a virtual env to make copying to the final image without all the upstream stuff easier.
+ENV PYTHONPATH="/code/tests/app/idp:$PYTHONPATH"
+# need to update pip and setuptools for pep517 support required by gevent.
 
 
+WORKDIR /code
+COPY ./pyproject.toml /code
+COPY ./uv.lock /code
+COPY ./oauth2_provider /code/oauth2_provider
 
+RUN uv sync --extra dev
 
-COPY --from=builder /opt/venv /opt/venv
-ENV PATH="/opt/venv/bin:$PATH"
-COPY --from=builder /code /code
-RUN mkdir -p /code/tests/app/idp/static /code/tests/app/idp/templates
+COPY ./tests /code/tests
+
 WORKDIR /code/tests/app/idp
-RUN apt-get update && apt-get install -y \
-    libpq5 \
-    && rm -rf /var/lib/apt/lists/*
-EXPOSE 80
-VOLUME ["/data" ]
-CMD ["gunicorn",  "idp.wsgi:application",  "-w 4 -b 0.0.0.0:80 --chdir=/code --worker-tmp-dir /dev/shm --timeout 120  --error-logfile '-' --log-level debug --access-logfile '-'"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,50 @@
-volumes:
-  idp-data:
-
+x-idp-network: &idp-network
+  networks:
+    - idp-net
 
 x-idp: &idp
+  <<: *idp-network
   image: django-oauth-toolkit/idp
+  build: .
+  stdin_open: true
+  tty: true
   volumes:
+    - ./:/code
     - idp-data:/data
+    - static-data:/var/oauth/static
+  command: uv run django-admin runserver 0.0.0.0:80
+
+  environment: &fediverser-service-environment
+    DJANGO_SETTINGS_MODULE: idp.settings
+    STATIC_ROOT: /var/oauth/static
+    ALLOWED_HOSTS: "*"
+    TEMPLATES_DIRS: /code/tests/app/idp/templates
+    DATABASE_URL: sqlite:////data/db.sqlite3
+
+  env_file:
+    - .env
 
 services:
+  idp-collectstatic:
+    <<: *idp
+    command: uv run django-admin collectstatic --noinput
+    restart: on-failure
+
   idp-migrate:
     <<: *idp
-    build: .
-    command: python manage.py migrate
+    command: uv run django-admin migrate
+    depends_on:
+      - idp-collectstatic
 
   idp-loaddata:
     <<: *idp
-    command: python manage.py loaddata fixtures/seed.json
+    command: uv run django-admin loaddata fixtures/seed.json
     depends_on:
       idp-migrate:
         condition: service_completed_successfully
 
   idp:
     <<: *idp
-    command: gunicorn idp.wsgi:application -w 4 -b 0.0.0.0:80 --chdir=/code --timeout 120  --error-logfile '-' --log-level debug --access-logfile '-'
     ports:
       # map to dev port.
       - "8000:80"
@@ -38,3 +60,10 @@ services:
       - "5173:3000"
     depends_on:
       - idp
+
+networks:
+  idp-net:
+
+volumes:
+  idp-data:
+  static-data:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -12,10 +12,30 @@ This is a `Jazzband <https://jazzband.co>`_ project. By contributing you agree t
 Setup
 =====
 
-Fork ``django-oauth-toolkit`` repository on `GitHub <https://github.com/jazzband/django-oauth-toolkit>`_ and follow these steps:
 
- * Create a virtualenv and activate it
- * Clone your repository locally
+Fork ``django-oauth-toolkit`` repository on `GitHub
+<https://github.com/jazzband/django-oauth-toolkit>`_ and clone to your
+development machine. The recommended method to manage your development
+environment is to use `uv <https://docs.astral.sh/uv/>`_, but you can
+also use pip directly to manage the virtual environment.
+
+
+Running the test IDP and RP applications (Docker)
+=================================================
+
+During development, it might be helpful to run an application that
+actually exercises the many authentication flows. We provide a django
+project that can be set up to run as the Identity Provider (IDP) and a
+separate Javascript application that works as the Relying Party (RP).
+If you have docker and docker-compose configured, you can get them
+both the services running with a few simple steps:
+
+ - make a copy of the ``.env.sample.docker`` to ``.env`` and make changes as desired
+ - Run ``docker-compose up -d --build``
+
+The IDP service will be available on `http://localhost:8000` and the
+RP service will be available on `http://localhost:5173`
+
 
 Issues
 ======

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,9 @@ dev = [
 	"pytest",
 	"pytest-cov",
 	"m2r",
-	"sphinx-rtd-theme",
+    "sphinx-rtd-theme",
+    "django-cors-headers",
+    "django-environ",
 ]
 
 [project.urls]

--- a/tests/app/idp/idp/urls.py
+++ b/tests/app/idp/idp/urls.py
@@ -15,11 +15,13 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
+from django.conf import settings
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 
 
-urlpatterns = [
+urlpatterns = static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) + [
     path("admin/", admin.site.urls),
     path("o/", include("oauth2_provider.urls", namespace="oauth2_provider")),
     path("accounts/", include("django.contrib.auth.urls")),

--- a/tests/app/idp/requirements.txt
+++ b/tests/app/idp/requirements.txt
@@ -1,5 +1,0 @@
-Django>=4.2,<=5.1
-django-cors-headers==3.14.0
-django-environ==0.11.2
-
--e ../../../


### PR DESCRIPTION
I couldn't find anything in the documentation indicating how to set up the docker service for development. The  Dockerfile is outdated (the second target is setup to run the idp project, but the env variables defined are not matching) and not really reflecting the current tooling used elsewhere. The docker-compose also does not have any mechanism to set an environment file which makes it hard to make changes.


<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1548 

## Description of the Change

The Dockerfile now is used only to give a container with all the installed dependencies, and the docker-compose is focused on a development workflow, the application code is loaded as a volume, so changes in the code repository are immediately available inside the container. Environment variables that are specific to the development environment are defined in the dockerc-compose file, and environment variables that might be controlled by the developer (e.g, whether to enable or disable OIDC), can be configured through a .env file placed at the root of the project.




## Checklist

- [X] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [X] documentation updated
- [X] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
