### PR TITLE
fix: idp image can't find templates or statics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1517 OP prompts for logout when no OP session
 * #1512 client_secret not marked sensitive
 * #1521 Fix 0012 migration loading access token table into memory
+* #1584 Fix IDP container in docker compose environment could not find templates and static files.
 <!--
 ### Security
 -->

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,10 @@ ENV DATABASE_URL="sqlite:////data/db.sqlite3"
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 COPY --from=builder /code /code
-RUN mkdir -p /code/tests/app/idp/static /code/tests/app/idp/templates
+RUN mkdir -p /data/static /data/templates
+COPY --from=builder /code/tests/app/idp/static /data/static
+COPY --from=builder /code/tests/app/idp/templates /data/templates
+
 WORKDIR /code/tests/app/idp
 RUN apt-get update && apt-get install -y \
     libpq5 \

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -325,6 +325,28 @@ Reviewing and Merging PRs
 
 PRs that are incorrectly merged may (reluctantly) be reverted by the Project Leads.
 
+End to End Testing
+------------------
+
+There is a demonstration Identity Provider (IDP) and Relying Party (RP) to allow for
+end to end testing. They can be launched directly by following the instructions in
+/test/apps/README.md or via docker compose. To launch via docker compose
+
+.. code-block:: bash
+
+    # build the images with the current code
+    docker compose build
+    # wipe any existing services and volumes
+    docker compose rm -v
+    # start the services
+    docker compose up -d
+
+Please verify the RP behaves as expected by logging in, reloading, and logging out.
+
+open http://localhost:5173 in your browser and login with the following credentials:
+
+username: superuser
+password: password
 
 Publishing a Release
 --------------------


### PR DESCRIPTION
Fixes #1584

## Description of the Change
Copy the static files and templates to the path that the IDP was expecting them to be at. 

## Checklist
- [X] PR only contains one change (considered splitting up PR)
- [ ] unit-test added - N/A we don't have a testing harness for the container yet
- [X] documentation updated
- [X] `CHANGELOG.md` updated
- [X] author name in `AUTHORS`
