### PR TITLE
Fix DeprecationWarnings by updating key type property usage in tests

### DIFF
--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -1867,7 +1867,7 @@ class TestOIDCAuthorizationCodeHSAlgorithm(BaseAuthorizationCodeTokenView):
 
         # Check decoding JWT using HS256
         key = self.application.jwk_key
-        assert key.key_type == "oct"
+        assert key.kty == "oct"
         jwt_token = jwt.JWT(key=key, jwt=content["id_token"])
         claims = json.loads(jwt_token.claims)
         assert claims["sub"] == "1"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -563,7 +563,7 @@ def test_clear_expired_id_tokens(oauth2_settings, oidc_tokens, rf):
 def test_application_key(oauth2_settings, application):
     # RS256 key
     key = application.jwk_key
-    assert key.key_type == "RSA"
+    assert key.kty == "RSA"
 
     # RS256 key, but not configured
     oauth2_settings.OIDC_RSA_PRIVATE_KEY = None
@@ -574,7 +574,7 @@ def test_application_key(oauth2_settings, application):
     # HS256 key
     application.algorithm = Application.HS256_ALGORITHM
     key = application.jwk_key
-    assert key.key_type == "oct"
+    assert key.kty == "oct"
 
     # No algorithm
     application.algorithm = Application.NO_ALGORITHM


### PR DESCRIPTION
Fixes #1483.

Replaced deprecated key.key_type with key.kty in test files to remove DeprecationWarnings and ensure compatibility with latest dependencies.

Single change (remove DeprecationWarnings).