### PR TITLE
chore: exclude invalid djmain/py combinations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
         - '5.1'
         - '5.2'
         - 'main'
+        ## include/exclude combinations, typically for the newest and oldest django/python versions.
         include:
           # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
           - python-version: '3.8'
@@ -41,6 +42,10 @@ jobs:
             django-version: '5.0'
           - python-version: '3.13'
             django-version: '4.2'
+          - python-version: '3.10'
+            django-version: 'main'
+          - python-version: '3.11'
+            django-version: 'main'
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Description of the Change
django 6 drops support for python 3.10 and 3.11, so we're removing those pairings from the test matrix

## Checklist
- [X] PR only contains one change (considered splitting up PR)
- [n/a] unit-test added
- [n/a] documentation updated
- [n/a] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
- [n/a] tests/app/idp updated to demonstrate new features
- [n/a] tests/app/rp updated to demonstrate new features
