### PR TITLE
chore: defer codecov notify until all jobs done

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,10 +117,30 @@ jobs:
         run: npm run build
         working-directory: tests/app/rp
 
+  codecov-notify:
+    needs:
+      - test-package
+      - test-demo-rp
+    runs-on: ubuntu-latest
+    name: Codecov Notify
+    steps:
+      # - tell codecov to send notifications now that all jobs are complete. 
+      #   without this, codecov may notify before all coverage reports have been uploaded.
+      #   `codecov: notify: manual_trigger: true` must be set in codecov.yml, to prevent 
+      #   processing on every upload.
+      # - preferred to after_n_builds so we don't need to update that number every
+      #   time we add/remove jobs.
+      - name: Notify Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          run_command: 'send-notifications'
+          use_oidc: true
+
   success:
     needs:
       - test-package
       - test-demo-rp
+      - codecov-notify
     runs-on: ubuntu-latest
     name: Test successful
     steps:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+
+codecov:
+  # since we're uploading coverage from multiple parallel jobs,Codecov doesn't
+  # inherently know when all reports have been uploaded for a given commit. To
+  # prevent premature processing and ensure a complete report, we send
+  # notification when all jobs are done.
+  notify:
+    manual_trigger: true


### PR DESCRIPTION
## Description of the Change
Defer codecov processing and notifications until all jobs are complete, to prevent premature notification. 

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [X] PR only contains one change (considered splitting up PR)
- [n/a] unit-test added
- [X] documentation updated
- [n/a] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
- [n/a] tests/app/idp updated to demonstrate new features
- [n/a] tests/app/rp updated to demonstrate new features
