### PR TITLE
chore: ignore *.orig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ db.sqlite3
 venv/
 
 /tests/app/idp/static
+
+*.orig


### PR DESCRIPTION
we don't want these accidentally getting added to the repo.

