### PR TITLE
chore: fix codecov notify permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,8 @@ jobs:
       - test-demo-rp
     runs-on: ubuntu-latest
     name: Codecov Notify
+    permissions:
+      id-token: write # Required for Codecov OIDC token
     steps:
       # - tell codecov to send notifications now that all jobs are complete. 
       #   without this, codecov may notify before all coverage reports have been uploaded.


### PR DESCRIPTION
## Description of the Change

It seems the codecov notify task may have insufficient privileges.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [X] PR only contains one change (considered splitting up PR)
- [n/a] unit-test added
- [n/a] documentation updated
- [n/a] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
- [n/a] tests/app/idp updated to demonstrate new features
- [n/a] tests/app/rp updated to demonstrate new features
