### PR TITLE
Fix documentation build warnings (#1484)

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -258,7 +258,7 @@ For test writers this means any test must either:
 - when using pytest's `django_db` mark, define it like this:
   `@pytest.mark.django_db(databases=retrieve_current_databases())`
 
-In test code, anywhere the database is referenced the Django router needs to be used exactly like the package's code.
+In test code, anywhere the database is referenced the Django router needs to be used exactly like the package's code:
 
 .. code-block:: python
 

--- a/docs/management_commands.rst
+++ b/docs/management_commands.rst
@@ -32,7 +32,7 @@ createapplication
 
 The ``createapplication`` management command provides a shortcut to create a new application in a programmatic way.
 
-.. code-block:: sh
+.. code-block:: text
 
     usage: manage.py createapplication [-h] [--client-id CLIENT_ID] [--user USER]
                                        [--redirect-uris REDIRECT_URIS]

--- a/docs/oidc.rst
+++ b/docs/oidc.rst
@@ -288,7 +288,10 @@ mapping a claim name to claim data::
 
 The second form gets no request object, and should return a dictionary
 mapping a claim name to a callable, accepting a request and producing
-the claim data::
+the claim data:
+
+.. code-block:: python
+
     class CustomOAuth2Validator(OAuth2Validator):
         # Extend the standard scopes to add a new "permissions" scope
         # which returns a "permissions" claim:
@@ -332,7 +335,10 @@ For example, a ``given_name`` claim is only returned if the ``profile`` scope wa
 
 To change the list of claims and which scopes result in their being returned,
 override ``oidc_claim_scope`` with a dict keyed by claim with a value of scope.
-The following example adds instructions to return the ``foo`` claim when the ``bar`` scope is granted::
+The following example adds instructions to return the ``foo`` claim when the ``bar`` scope is granted:
+
+.. code-block:: python
+
     class CustomOAuth2Validator(OAuth2Validator):
         oidc_claim_scope = OAuth2Validator.oidc_claim_scope
         oidc_claim_scope.update({"foo": "bar"})

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -354,7 +354,7 @@ If unset, the default location is used, eg if ``django-oauth-toolkit`` is
 mounted at ``/o/``, it will be ``<server-address>/o/userinfo/``.
 
 OIDC_RP_INITIATED_LOGOUT_ENABLED
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Default: ``False``
 
 When is set to ``False`` (default) the `OpenID Connect RP-Initiated Logout <https://openid.net/specs/openid-connect-rpinitiated-1_0.html>`_
@@ -369,13 +369,13 @@ Whether to always prompt the :term:`Resource Owner` (End User) to confirm a logo
 :term:`Client` (Relying Party). If it is disabled the :term:`Resource Owner` (End User) will only be prompted if required by the standard.
 
 OIDC_RP_INITIATED_LOGOUT_STRICT_REDIRECT_URIS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Default: ``False``
 
 Enable this setting to require `https` in post logout redirect URIs. `http` is only allowed when a :term:`Client` is `confidential`.
 
 OIDC_RP_INITIATED_LOGOUT_ACCEPT_EXPIRED_TOKENS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Default: ``True``
 
 Whether expired ID tokens are accepted for RP-Initiated Logout. The Tokens must still be signed by the OP and otherwise valid.

--- a/docs/views/details.rst
+++ b/docs/views/details.rst
@@ -17,6 +17,7 @@ inside their Django applications.
 
 .. automodule:: oauth2_provider.views.mixins
     :members:
+    :noindex:
 
 Base
 ----

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -562,7 +562,7 @@ class RefreshToken(AbstractRefreshToken):
 class AbstractIDToken(models.Model):
     """
     An IDToken instance represents the actual token to
-    access user's resources, as in :openid:`2`.
+    access user's resources, as defined in the OpenID Connect specification.
 
     Fields:
 


### PR DESCRIPTION
Fixes all Sphinx documentation build warnings by correcting RST formatting issues: title underlines, code block directives, undefined role reference, and duplicate object descriptions.

Fixes #1484