### PR TITLE
fix: use token_checksum for lookup in _get_token_from_authentication_server

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,6 +61,7 @@ Frederico Vieira
 Gaël Utard
 Glauco Junior
 Giovanni Giampauli
+Hamid Hashemi
 Hasan Ramezani
 Hiroki Kiyohara
 Hossein Shakiba

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -445,9 +445,11 @@ class OAuth2Validator(RequestValidator):
                     expires, timezone=get_timezone(oauth2_settings.AUTHENTICATION_SERVER_EXP_TIME_ZONE)
                 )
 
+            token_checksum = hashlib.sha256(token.encode("utf-8")).hexdigest()
             access_token, _created = AccessToken.objects.update_or_create(
-                token=token,
+                token_checksum=token_checksum,
                 defaults={
+                    "token": token,
                     "user": user,
                     "application": None,
                     "scope": scope,


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #

## Description of the Change
This PR improves lookup performance in OAuth2Validator._get_token_from_authentication_server by using the indexed token_checksum field instead of the unindexed token field.
## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features
