### PR TITLE
fix python version to allow 3.14.* (anything <3.15)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "django-oauth-toolkit"
 dynamic = ["version"]
-requires-python = ">=3.8,<3.15"
+requires-python = ">=3.8"
 authors = [
   {name = "Federico Frenguelli"},
   {name = "Massimiliano Pippi"},


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
testing for <= 3.14 breaks on minor releases like 3.14.2

## Description of the Change
Fixed pyproject.toml to test for <3.15

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features
