### PR TITLE
chore: Add support for Django 6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,21 +26,20 @@ jobs:
         - '5.1'
         - '5.2'
         - 'main'
-        ## include/exclude combinations, typically for the newest and oldest django/python versions.
+        ## include/exclude version combinations, typically for the newest and oldest django/python versions.
+        ## python-version and django-version should be selected such that they minimize the number of include
+        ## and exclude entries.
         include:
-          - python-version: '3.14'
-            django-version: '5.2'
-          - python-version: '3.14'
-            django-version: 'main'
+          - { django-version: '5.2', python-version: '3.14' }
+          - { django-version: '6.0', python-version: '3.12' }
+          - { django-version: '6.0', python-version: '3.13' }
+          - { django-version: '6.0', python-version: '3.14' }
+          - { django-version: 'main', python-version: '3.14' }
         exclude:
-          - python-version: '3.13'
-            django-version: '5.0'
-          - python-version: '3.13'
-            django-version: '4.2'
-          - python-version: '3.10'
-            django-version: 'main'
-          - python-version: '3.11'
-            django-version: 'main'
+          - { django-version: '4.2', python-version: '3.13' }
+          - { django-version: '5.0', python-version: '3.13' }
+          - { django-version: 'main', python-version: '3.10' }
+          - { django-version: 'main', python-version: '3.11' }
 
     steps:
     - uses: actions/checkout@v4
@@ -49,7 +48,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-
 
     - name: Get pip cache dir
       id: pip-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+* #1637 Support for Django 6.0
+
 ### Removed
 * #1636 Remove support for Python 3.8 and 3.9
 
 ### Fixed
 * #1628 Fix inaccurate help_text on client_secret field of Application model
-
 
 ## [3.2.0] - 2025-11-13
 ### Added

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Requirements
 ------------
 
 * Python 3.10, 3.11, 3.12, 3.13 or 3.14
-* Django 4.2, 5.0, 5.1 or 5.2
+* Django 4.2, 5.0, 5.1, 5.2 or 6.0
 * oauthlib 3.2.2+
 
 Installation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 * Python 3.10, 3.11, 3.12, 3.13 or 3.14
-* Django 4.2, 5.0, 5.1 or 5.2
+* Django 4.2, 5.0, 5.1, 5.2 or 6.0
 * oauthlib 3.2.2+
 
 Index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 	"Framework :: Django :: 5.0",
 	"Framework :: Django :: 5.1",
 	"Framework :: Django :: 5.2",
+	"Framework :: Django :: 6.0",
 	"Intended Audience :: Developers",
 	"License :: OSI Approved :: BSD License",
 	"Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,9 @@ envlist =
     py{310,311,312,313}-dj50,
     py{310,311,312,313}-dj51,
     py{310,311,312,313,314}-dj52,
-    py{310,311,312,313,314}-djmain,
-    py314-multi-db-dj-42
+    py{312,313,314}-dj60,
+    py{312,313,314}-djmain,
+    py314-dj42-multi-db,
 
 [gh-actions]
 python =
@@ -26,6 +27,7 @@ DJANGO =
     5.0: dj50
     5.1: dj51
     5.2: dj52
+    6.0: dj60
     main: djmain
 
 [testenv]
@@ -42,6 +44,7 @@ deps =
     dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
     dj52: Django>=5.2,<6.0
+    dj60: Django>=6.0,<6.1
     djmain: https://github.com/django/django/archive/main.tar.gz
     djangorestframework
     oauthlib>=3.3.0
@@ -99,7 +102,7 @@ setenv =
     PYTHONWARNINGS = all
 commands = django-admin makemigrations --dry-run --check
 
-[testenv:py314-multi-db-dj42]
+[testenv:py314-dj42-multi-db]
 setenv =
     DJANGO_SETTINGS_MODULE = tests.multi_db_settings
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
- organized the includes and excludes so they're 1 line per entry

    the side by side versions are visually easier for me to parse than the stacking.
    I put django-version is first since I'm typically looking up supported python
    version by django version when updating the includes and excluded.

Fixes #

## Description of the Change

## Checklist

- [X] PR only contains one change (considered splitting up PR)
- [N/A] unit-test added
- [X] documentation updated
- [X] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
- [N/A] tests/app/idp updated to demonstrate new features
- [N/A] tests/app/rp updated to demonstrate new features
